### PR TITLE
Fix chromium path issue

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
-    "@sparticuz/chromium-min": "^123.0.1",
+    "@sparticuz/chromium": "^127.0.0",
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",

--- a/backend/server.js
+++ b/backend/server.js
@@ -9,7 +9,7 @@ const OpenAI = require('openai');
 const fs = require('fs');
 
 // --- PUPPETEER GÜNCELLEMESİ (BULUT ORTAMLARI İÇİN) ---
-const chromium = require('@sparticuz/chromium-min');
+const chromium = require('@sparticuz/chromium');
 const puppeteer = require('puppeteer-core'); // 'puppeteer' yerine 'puppeteer-core' kullanılıyor
 
 const app = express();


### PR DESCRIPTION
## Summary
- upgrade to `@sparticuz/chromium`
- update require path in server.js

## Testing
- `npm test --workspace=frontend --silent`
- `node backend/server.js` (fails without OPENAI_API_KEY)
- `OPENAI_API_KEY=sk-test node backend/server.js`

------
https://chatgpt.com/codex/tasks/task_e_688b86e003b4832795e74dd7e941d688