### PR TITLE
Align prompts with target CV language

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,8 @@ This repository contains a simple CV improvement tool with a React frontend and 
 ## Upload directory
 
 Uploaded CV files are stored inside the `data/` folder at the project root. If you want them to appear in your GitHub repository, commit and push the files in that directory.
+
+## Sample CV JSON Structure
+
+The `sample_cv_template.json` file at the project root demonstrates the fields our application expects when building a CV. You can use it as a reference for the ideal structure produced after parsing and follow‑up questions.
+

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -64,17 +64,19 @@ function App() {
     setError('');
     const formData = new FormData();
     formData.append('cv', file);
-    formData.append('appLanguage', i18n.language);
+    // send the language used for follow-up questions
+    formData.append('appLanguage', cvLanguage);
     formData.append('cvLanguage', cvLanguage);
 
     try {
       const res = await axios.post(`${API_BASE_URL}/api/initial-parse`, formData, { timeout: 45000 });
       setCvData(res.data.parsedData);
       const initialMsgs = [];
+      const tCv = i18n.getFixedT(cvLanguage);
       if (!res.data.parsedData?.personalInfo?.name && !res.data.parsedData?.personalInfo?.firstName) {
-        initialMsgs.push({ type: 'ai', text: t('askName') });
+        initialMsgs.push({ type: 'ai', text: tCv('askName') });
       }
-      initialMsgs.push({ type: 'ai', text: t('welcomeQuestion') });
+      initialMsgs.push({ type: 'ai', text: tCv('welcomeQuestion') });
       setConversation(initialMsgs);
       setStep('chat');
     } catch (err) {
@@ -102,7 +104,8 @@ function App() {
       const res = await axios.post(`${API_BASE_URL}/api/next-step`, {
         conversationHistory: JSON.stringify(newConversation),
         cvData,
-        appLanguage: i18n.language
+        // Use the target CV language for follow-up questions
+        appLanguage: cvLanguage
       });
 
       let updatedCvData = JSON.parse(JSON.stringify(cvData));

--- a/sample_cv_template.json
+++ b/sample_cv_template.json
@@ -1,0 +1,47 @@
+{
+  "personalInfo": {
+    "name": "John Doe",
+    "email": "john.doe@example.com",
+    "phone": "+1 555-1234",
+    "location": "New York, USA"
+  },
+  "summary": "Experienced professional with a background in software engineering.",
+  "experience": [
+    {
+      "title": "Senior Developer",
+      "company": "Tech Corp",
+      "location": "New York, USA",
+      "date": "2022 - Present",
+      "description": "- Developed scalable web applications\n- Led a team of 5 engineers"
+    }
+  ],
+  "education": [
+    {
+      "degree": "B.Sc. Computer Science",
+      "institution": "State University",
+      "date": "2018"
+    }
+  ],
+  "certificates": [
+    "AWS Certified Solutions Architect"
+  ],
+  "skillsByCategory": [
+    {
+      "category": "Programming",
+      "skills": ["JavaScript", "Python", "Java"]
+    }
+  ],
+  "languages": [
+    {
+      "language": "English",
+      "proficiency": "Native"
+    }
+  ],
+  "projects": [
+    {
+      "name": "Project X",
+      "description": "An innovative platform for data analytics",
+      "url": "https://example.com"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- send the CV language for question prompts
- ensure initial questions use the CV language
- document the sample JSON structure and provide an example template

## Testing
- `npm test --workspaces --if-present` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688ba3edac448327bb33169deb012693