### PR TITLE
Improve language flow and server logging

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -70,10 +70,11 @@ body {
 }
 .settings-bar {
     position: absolute;
-    top: 20px;
-    right: 20px;
+    top: 10px;
+    right: 10px;
     display: flex;
     gap: 10px;
+    z-index: 10;
 }
 .language-switcher, .theme-switcher {
     display: flex;
@@ -115,7 +116,7 @@ footer {
 .upload-step {
     position: relative;
     background-color: var(--surface-color);
-    padding: 2rem 3rem 1rem 3rem; /* Footer için alt padding azaltıldı */
+    padding: 4rem 3rem 1rem 3rem; /* Üst kısım için ekstra boşluk */
     border-radius: 12px;
     box-shadow: var(--shadow);
     text-align: center;
@@ -141,7 +142,7 @@ input[type="file"] { display: none; }
     flex-direction: column;
     width: 100%;
     max-width: 700px;
-    height: 90vh;
+    height: 90dvh;
     background-color: var(--surface-color);
     border-radius: 12px;
     box-shadow: var(--shadow);
@@ -180,9 +181,8 @@ input[type="file"] { display: none; }
 /* Mobil Uyumluluk */
 @media (max-width: 768px) {
     .app-container { height: 100%; padding: 0; }
-    .chat-step, .upload-step { height: 100vh; width: 100vw; border-radius: 0; max-width: 100vw; box-sizing: border-box; }
+    .chat-step, .upload-step { height: 100dvh; width: 100vw; border-radius: 0; max-width: 100vw; box-sizing: border-box; }
     .upload-step { justify-content: center; }
     .button-group { flex-wrap: wrap; }
-    .chat-header .logo-container span { display: none; }
     .settings-bar { gap: 5px;}
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -65,18 +65,18 @@ function App() {
     const formData = new FormData();
     formData.append('cv', file);
     // send the language used for follow-up questions
-    formData.append('appLanguage', cvLanguage);
+    formData.append('appLanguage', i18n.language);
     formData.append('cvLanguage', cvLanguage);
 
     try {
       const res = await axios.post(`${API_BASE_URL}/api/initial-parse`, formData, { timeout: 45000 });
       setCvData(res.data.parsedData);
       const initialMsgs = [];
-      const tCv = i18n.getFixedT(cvLanguage);
+      const tApp = i18n.getFixedT(i18n.language);
       if (!res.data.parsedData?.personalInfo?.name && !res.data.parsedData?.personalInfo?.firstName) {
-        initialMsgs.push({ type: 'ai', text: tCv('askName') });
+        initialMsgs.push({ type: 'ai', text: tApp('askName') });
       }
-      initialMsgs.push({ type: 'ai', text: tCv('welcomeQuestion') });
+      initialMsgs.push({ type: 'ai', text: tApp('welcomeQuestion') });
       setConversation(initialMsgs);
       setStep('chat');
     } catch (err) {
@@ -104,8 +104,8 @@ function App() {
       const res = await axios.post(`${API_BASE_URL}/api/next-step`, {
         conversationHistory: JSON.stringify(newConversation),
         cvData,
-        // Use the target CV language for follow-up questions
-        appLanguage: cvLanguage
+        // Use the current UI language for follow-up questions
+        appLanguage: i18n.language
       });
 
       let updatedCvData = JSON.parse(JSON.stringify(cvData));

--- a/frontend/src/components/LanguageSwitcher.js
+++ b/frontend/src/components/LanguageSwitcher.js
@@ -1,18 +1,26 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-// Doğrulanmış ve Estetik Bayrak SVG'leri
-const TrFlag = () => <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48"><path fill="#e60013" d="M0 0h48v48H0z" /><circle cx="18" cy="24" r="8" fill="#fff" /><circle cx="21" cy="24" r="6" fill="#e60013" /><path fill="#fff" d="m31.32 24.3-3.64-1.92-1.4 3.96 1.4-3.97L24 18.73l1.4 3.96 3.65-1.92-3.64 1.93 2.25 3.3z" /></svg>;
-const UsFlag = () => <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 7410 3900"><path fill="#b22234" d="M0 0h7410v3900H0z" /><path d="M0 450h7410V300H0zm0 600h7410V750H0zm0 600h7410v-150H0zM0 2250h7410v-150H0zM0 2850h7410v-150H0zm0 600h7410v-150H0z" fill="#fff" /><path fill="#3c3b6e" d="M0 0h2964v2100H0z" /><g fill="#fff"><g id="s18"><g id="s9"><path id="s" d="m1482 1050 42 129-110-79h136l-110 79z" /><use href="#s" x="296.4" /></g><use href="#s9" x="592.8" /><use href="#s" x="148.2" y="210" /><use href="#s9" x="296.4" y="210" /><use href="#s9" x="592.8" y="210" /></g><use href="#s18" y="420" /></g></svg>;
-
 function LanguageSwitcher() {
   const { i18n } = useTranslation();
   const changeLanguage = (lng) => i18n.changeLanguage(lng);
 
   return (
     <div className="language-switcher">
-      <button onClick={() => changeLanguage('tr')} className={i18n.language === 'tr' ? 'active' : ''} aria-label="Türkçe"><TrFlag /></button>
-      <button onClick={() => changeLanguage('en')} className={i18n.language.startsWith('en') ? 'active' : ''} aria-label="English"><UsFlag /></button>
+      <button
+        onClick={() => changeLanguage('tr')}
+        className={i18n.language === 'tr' ? 'active' : ''}
+        aria-label="Türkçe"
+      >
+        🇹🇷
+      </button>
+      <button
+        onClick={() => changeLanguage('en')}
+        className={i18n.language.startsWith('en') ? 'active' : ''}
+        aria-label="English"
+      >
+        🇺🇸
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- send follow-up questions using the UI language
- expand initial analysis prompt and load JSON template
- add simple step logger on the backend

## Testing
- `npm test --workspace=frontend --silent --if-present`
- `npm test --workspace=backend --silent`

------
https://chatgpt.com/codex/tasks/task_e_688bba4164748327b3e0a6d8d4ca08d2