### PR TITLE
Fix final message duplication and improve PDF flow

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -154,25 +154,30 @@ function App() {
       link.parentNode.removeChild(link);
       window.URL.revokeObjectURL(url);
 
-      // PDF indirildikten sonra sohbeti son adıma taşı ve "typing" göster
-      setConversation(prev => [...prev, { type: 'ai', text: t('finalMessage') }, { type: 'typing' }]);
+      // PDF indirildikten sonra sadece bir "typing" mesajı göster
+      setConversation(prev => [...prev, { type: 'typing' }]);
       setStep('final');
 
       // ADIM 2: Arka planda ön yazı metnini iste
-      const coverLetterResponse = await axios.post(`${API_BASE_URL}/api/generate-cover-letter`, {
-        cvData, // AI'ın son CV'yi kullanması için cvData'yı gönderiyoruz
-        appLanguage: i18n.language
-      });
+      try {
+        const coverLetterResponse = await axios.post(`${API_BASE_URL}/api/generate-cover-letter`, {
+          cvData, // AI'ın son CV'yi kullanması için cvData'yı gönderiyoruz
+          appLanguage: i18n.language
+        });
 
-      // ADIM 3: Ön yazıyı al ve "typing" göstergesini kaldırarak sohbete ekle
-      setConversation(prev => {
-        const newConversation = prev.filter(msg => msg.type !== 'typing'); // typing'i kaldır
-        if (coverLetterResponse.data.coverLetter) {
-          const fullCoverLetterMessage = `${t('coverLetterIntro')}\n\n"${coverLetterResponse.data.coverLetter}"`;
-          newConversation.push({ type: 'ai', text: fullCoverLetterMessage });
-        }
-        return newConversation;
-      });
+        // ADIM 3: Ön yazıyı al ve "typing" göstergesini kaldırarak sohbete ekle
+        setConversation(prev => {
+          const newConversation = prev.filter(msg => msg.type !== 'typing'); // typing'i kaldır
+          if (coverLetterResponse.data.coverLetter) {
+            const fullCoverLetterMessage = `${t('coverLetterIntro')}\n\n"${coverLetterResponse.data.coverLetter}"`;
+            newConversation.push({ type: 'ai', text: fullCoverLetterMessage });
+          }
+          return newConversation;
+        });
+      } catch (coverErr) {
+        // Ön yazı alınamazsa sadece typing'i kaldır, hata göstermeye gerek yok
+        setConversation(prev => prev.filter(msg => msg.type !== 'typing'));
+      }
 
     } catch (err) {
       setConversation(prev => prev.filter(msg => msg.type !== 'typing')); // Hata durumunda da typing'i kaldır

--- a/frontend/src/locales/tr/translation.json
+++ b/frontend/src/locales/tr/translation.json
@@ -14,7 +14,7 @@
   "finishButton": "CV'mi Oluştur & İndir",
   "generatingPdfButton": "PDF Sonlandırılıyor...",
   "coverLetterIntro": "İşte yeni CV'nize dayalı, ilgi çekici bir ön yazı girişi taslağı. Bunu kopyalayıp iş başvurularınız için uyarlayabilirsiniz:",
-  "finalMessage": "CV'niz başarıyla oluşutuldu ve indirmeye hazır!",
+  "finalMessage": "CV'niz başarıyla oluşturuldu ve indirmeye hazır!",
   "errorOccurred": "Bir hata oluştu. Lütfen tekrar deneyin.",
   "chatError": "Sohbet sırasında bir hata oluştu.",
   "pdfError": "PDF oluşturulurken bir hata oluştu.",


### PR DESCRIPTION
## Summary
- avoid adding final message twice when generating the PDF
- handle cover letter failures without raising a PDF error
- fix typo in Turkish translation

## Testing
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688cb86265988327b239864e53026615