### PR TITLE
Implement cover letter PDF download

### DIFF
--- a/backend/routes/api.js
+++ b/backend/routes/api.js
@@ -57,6 +57,22 @@ router.post('/generate-cover-letter', async (req, res) => {
     res.status(500).send({ message: 'Ön yazı metni üretilemedi.' });
   }
 });
+
+// Ön Yazı PDF'ini üretip indiren yeni uç nokta
+router.post('/generate-cover-letter-pdf', async (req, res) => {
+  try {
+    const { cvData, appLanguage } = req.body;
+    logStep("Ön Yazı PDF'i için istek alındı.");
+    const coverLetterText = await aiService.generateCoverLetterText(cvData, appLanguage);
+    const pdfBuffer = await pdfService.createCoverLetterPdf(coverLetterText);
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Disposition', 'attachment; filename=Cover_Letter.pdf');
+    res.send(pdfBuffer);
+  } catch (error) {
+    console.error("Ön Yazı PDF Hatası:", error);
+    res.status(500).send({ message: 'Ön yazı PDFi üretilemedi.' });
+  }
+});
 // --- YENİ BÖLÜMÜN SONU ---
 
 

--- a/frontend/src/services/apiService.js
+++ b/frontend/src/services/apiService.js
@@ -38,3 +38,16 @@ export async function finalizeAndCreatePdf(cvData, cvLanguage) {
   });
   return response.data;
 }
+
+/**
+ * CV verisine göre ön yazı PDF'i oluşturur ve indirir.
+ */
+export async function generateCoverLetterPdf(cvData, appLanguage) {
+  const response = await axios.post(`${API_BASE_URL}/api/generate-cover-letter-pdf`, {
+    cvData,
+    appLanguage
+  }, {
+    responseType: 'blob'
+  });
+  return response.data;
+}


### PR DESCRIPTION
## Summary
- generate a printable cover letter PDF in the backend
- expose new `/generate-cover-letter-pdf` API route
- add client helper for requesting the cover letter PDF
- trigger cover letter PDF download after creating the CV PDF

## Testing
- `CI=true npm --prefix frontend test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688ccbb6a46083278cf83036f9123437