### PR TITLE
Improve PDF handling and cover letter logs

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "CV Builder backend",
   "main": "server.js",
   "scripts": {
@@ -13,18 +13,18 @@
   "engines": {
     "node": "20.x"
   },
-"dependencies": {
-  "@sparticuz/chromium": "^123.0.1",
-  "cors": "^2.8.5",
-  "dotenv": "^16.4.5",
-  "express": "^4.19.2",
-  "mammoth": "^1.8.0",
-  "multer": "^1.4.5-lts.1",
-  "openai": "^4.52.7",
-  "pdf-parse": "^1.1.1",
-  "puppeteer": "^22.13.1",
-  "puppeteer-core": "^22.13.1"
-},
+  "dependencies": {
+    "@sparticuz/chromium": "^123.0.1",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "mammoth": "^1.8.0",
+    "multer": "^1.4.5-lts.1",
+    "openai": "^4.52.7",
+    "pdf-parse": "^1.1.1",
+    "puppeteer": "^22.13.1",
+    "puppeteer-core": "^22.13.1"
+  },
   "devDependencies": {
     "nodemon": "^3.1.4"
   }

--- a/backend/routes/api.js
+++ b/backend/routes/api.js
@@ -50,6 +50,7 @@ router.post('/generate-cover-letter', async (req, res) => {
     const { cvData, appLanguage } = req.body;
     logStep("Ön Yazı Metni için istek alındı.");
     const coverLetterText = await aiService.generateCoverLetterText(cvData, appLanguage);
+    logStep(`Ön Yazı Metni oluşturuldu: ${coverLetterText.slice(0,40)}...`);
     // Ön yazıyı bir JSON nesnesi içinde geri gönderiyoruz
     res.status(200).json({ coverLetter: coverLetterText });
   } catch (error) {
@@ -67,6 +68,7 @@ router.post('/generate-cover-letter-pdf', async (req, res) => {
     const pdfBuffer = await pdfService.createCoverLetterPdf(coverLetterText);
     res.setHeader('Content-Type', 'application/pdf');
     res.setHeader('Content-Disposition', 'attachment; filename=Cover_Letter.pdf');
+    logStep('Ön Yazı PDF buffer'ı oluşturuldu ve gönderiliyor.');
     res.send(pdfBuffer);
   } catch (error) {
     console.error("Ön Yazı PDF Hatası:", error);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "homepage": ".",
   "dependencies": {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -149,6 +149,7 @@ function App() {
       link.href = url;
       const fileName = (get(cvData, 'personalInfo.name') || 'Super_CV').replace(/\s+/g, '_') + '.pdf';
       link.setAttribute('download', fileName);
+      link.setAttribute('target', '_blank');
       document.body.appendChild(link);
       link.click();
       link.parentNode.removeChild(link);
@@ -188,6 +189,7 @@ function App() {
             pdfLink.href = pdfUrl;
             pdfLink.setAttribute('download', 'Cover_Letter.pdf');
             document.body.appendChild(pdfLink);
+            pdfLink.setAttribute('target', '_blank');
             pdfLink.click();
             pdfLink.parentNode.removeChild(pdfLink);
             window.URL.revokeObjectURL(pdfUrl);

--- a/package2.json
+++ b/package2.json
@@ -1,6 +1,6 @@
 {
   "name": "cvbuilder-monorepo",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "workspaces": [
     "frontend",


### PR DESCRIPTION
## Summary
- update front/back versions
- log cover letter generation
- force CV and cover letter PDFs to download in a new tab

## Testing
- `npm test --workspace=frontend --silent` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cd4be2f4c83279732a0c82044fa1a