### PR TITLE
Fix cover letter PDF log message quoting

### DIFF
--- a/backend/routes/api.js
+++ b/backend/routes/api.js
@@ -68,7 +68,7 @@ router.post('/generate-cover-letter-pdf', async (req, res) => {
     const pdfBuffer = await pdfService.createCoverLetterPdf(coverLetterText);
     res.setHeader('Content-Type', 'application/pdf');
     res.setHeader('Content-Disposition', 'attachment; filename=Cover_Letter.pdf');
-    logStep('Ön Yazı PDF buffer'ı oluşturuldu ve gönderiliyor.');
+    logStep("Ön Yazı PDF buffer'ı oluşturuldu ve gönderiliyor.");
     res.send(pdfBuffer);
   } catch (error) {
     console.error("Ön Yazı PDF Hatası:", error);


### PR DESCRIPTION
## Summary
- fix quoting in backend `generate-cover-letter-pdf` log message

## Testing
- `node backend/server.js` *(fails: OPENAI_API_KEY environment variable missing)*

------
https://chatgpt.com/codex/tasks/task_e_688cd819b35c832787a82f39d04bf31c