### PR TITLE
Improve PDF generation and localization

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "CV Builder backend",
   "main": "server.js",
   "scripts": {

--- a/backend/routes/api.js
+++ b/backend/routes/api.js
@@ -11,18 +11,18 @@ const router = express.Router();
 router.post('/extract-raw', fileService.upload.single('cv'), async (req, res) => {
   if (!req.file) return res.status(400).json({ message: "Dosya bulunamadı." });
   try {
-    await fileService.saveFile(req.file);
+    const { sessionId } = await fileService.saveFile(req.file);
     const text = await fileService.getTextFromFile(req.file);
     const template = fileService.getTemplate();
     const extractedData = await aiService.extractRawCvData(text, template);
-    res.status(200).json({ parsedData: extractedData });
+    res.status(200).json({ parsedData: extractedData, sessionId });
   } catch (error) { console.error("Adım 1 Hatası:", error); res.status(500).send({ message: 'CV analizi sırasında bir hata oluştu.' }); }
 });
 
 // ADIM 2: AI Sorularını Üret (Mevcut ve Doğru)
 router.post('/generate-ai-questions', async (req, res) => {
   try {
-    const { cvData, appLanguage } = req.body;
+    const { cvData, appLanguage } = req.body; // sessionId can be sent but is optional
     logStep("ADIM 2: AI için stratejik sorular üretiliyor.");
     const questionsData = await aiService.generateAiQuestions(cvData, appLanguage);
     res.json(questionsData);
@@ -32,14 +32,21 @@ router.post('/generate-ai-questions', async (req, res) => {
 // ADIM 3: Final PDF'i Oluştur (Mevcut ve Doğru)
 router.post('/finalize-and-create-pdf', async (req, res) => {
   try {
-    const { cvData, cvLanguage } = req.body;
+    const { cvData, cvLanguage, sessionId } = req.body;
     const finalCvData = await aiService.finalizeCvData(cvData, cvLanguage);
-    const pdfBuffer = await pdfService.createPdf(finalCvData);
+    const pdfBuffer = await pdfService.createPdf(finalCvData, cvLanguage);
+    if (sessionId) {
+      await fileService.saveBuffer(sessionId, 'final_cv.json', Buffer.from(JSON.stringify(finalCvData, null, 2)));
+      await fileService.saveBuffer(sessionId, 'cv.pdf', pdfBuffer);
+    }
     logStep("PDF başarıyla oluşturuldu ve gönderiliyor.");
     res.setHeader('Content-Type', 'application/pdf');
     res.setHeader('Content-Disposition', 'attachment; filename=Super_CV.pdf');
     res.send(pdfBuffer);
-  } catch (error) { console.error("Adım 3 Hatası:", error); res.status(500).send({ message: 'Final CV oluşturulamadı.' }); }
+  } catch (error) {
+    console.error("Adım 3 Hatası:", error);
+    res.status(500).send({ message: 'Final CV oluşturulamadı.' });
+  }
 });
 
 
@@ -47,10 +54,13 @@ router.post('/finalize-and-create-pdf', async (req, res) => {
 // ADIM 4: Ön Yazı Metnini Üret
 router.post('/generate-cover-letter', async (req, res) => {
   try {
-    const { cvData, appLanguage } = req.body;
+    const { cvData, appLanguage, sessionId } = req.body;
     logStep("Ön Yazı Metni için istek alındı.");
     const coverLetterText = await aiService.generateCoverLetterText(cvData, appLanguage);
     logStep(`Ön Yazı Metni oluşturuldu: ${coverLetterText.slice(0,40)}...`);
+    if (sessionId) {
+      await fileService.saveBuffer(sessionId, 'cover_letter.txt', Buffer.from(coverLetterText, 'utf8'));
+    }
     // Ön yazıyı bir JSON nesnesi içinde geri gönderiyoruz
     res.status(200).json({ coverLetter: coverLetterText });
   } catch (error) {
@@ -62,10 +72,13 @@ router.post('/generate-cover-letter', async (req, res) => {
 // Ön Yazı PDF'ini üretip indiren yeni uç nokta
 router.post('/generate-cover-letter-pdf', async (req, res) => {
   try {
-    const { cvData, appLanguage } = req.body;
+    const { cvData, appLanguage, sessionId } = req.body;
     logStep("Ön Yazı PDF'i için istek alındı.");
     const coverLetterText = await aiService.generateCoverLetterText(cvData, appLanguage);
     const pdfBuffer = await pdfService.createCoverLetterPdf(coverLetterText);
+    if (sessionId) {
+      await fileService.saveBuffer(sessionId, 'cover_letter.pdf', pdfBuffer);
+    }
     res.setHeader('Content-Type', 'application/pdf');
     res.setHeader('Content-Disposition', 'attachment; filename=Cover_Letter.pdf');
     logStep("Ön Yazı PDF buffer'ı oluşturuldu ve gönderiliyor.");

--- a/backend/services/aiService.js
+++ b/backend/services/aiService.js
@@ -31,13 +31,13 @@ const getExtractionPrompt = (cvText, template) => `
  * belirtilen dilde sorular üretmesini söyler. DİL KURALI ÇOK KESİNDİR.
  */
 const getAiQuestionsPrompt = (cvData, appLanguage) => `
-  You are a senior career coach. Analyze the provided CV JSON data. Your goal is to identify up to 4 of the most critical weaknesses or missing information that would significantly improve this CV.
+  You are a helpful career assistant. Carefully inspect the CV JSON below and identify up to 4 basic pieces of information that are missing or incomplete.
 
-  **CRITICAL RULES:**
-  1.  **LANGUAGE LOCK:** Your entire response, specifically the questions in the final JSON array, **MUST BE WRITTEN EXCLUSIVELY in the target language: '${appLanguage}'**. Do NOT use English or any other language unless '${appLanguage}' itself is English. This is your most important instruction. Failure to adhere to the language rule means the task is a failure.
-  2.  **NO REPEAT:** Do not ask for information that is already clearly present and detailed in the JSON (e.g., if 'email' has a value, do not ask for it).
-  3.  **IMPACT FOCUS:** Focus on impactful areas that are missing or weak: quantifiable achievements (e.g., "by X%"), project details, specific technical skills related to a job, or career objectives.
-  4.  **LIMIT:** Generate a maximum of 4 questions.
+  **RULES:**
+  1. **LANGUAGE LOCK:** Write every question only in '${appLanguage}'.
+  2. **BASIC INFO:** Focus on core CV details such as job titles, dates, education, key skills or contact information. Avoid overly advanced coaching advice.
+  3. **NO DUPLICATES:** Skip anything already filled in.
+  4. **LIMIT:** Maximum 4 short questions.
 
   Your final output MUST be a single JSON object with the key "questions", containing an array of strings.
   Example JSON output: { "questions": ["Question 1 in ${appLanguage}?", "Question 2 in ${appLanguage}?"] }

--- a/backend/services/pdfService.js
+++ b/backend/services/pdfService.js
@@ -28,7 +28,13 @@ const generateCoverLetterHtml = (text) => {
  * @param {object} data - CV verilerini içeren JSON nesnesi.
  * @returns {string} - PDF'e dönüştürülmeye hazır HTML string'i.
  */
-const generateCvHtml = (data) => {
+const headingMap = {
+    en: { summary: 'Summary', experience: 'Experience', education: 'Education', skills: 'Skills', projects: 'Projects', languages: 'Languages', certificates: 'Certificates', analysis: 'AI Analysis' },
+    tr: { summary: 'Özet', experience: 'Deneyim', education: 'Eğitim', skills: 'Yetenekler', projects: 'Projeler', languages: 'Diller', certificates: 'Sertifikalar', analysis: 'AI Analizi' }
+};
+
+const generateCvHtml = (data, language = 'en') => {
+    const t = headingMap[language] || headingMap.en;
     const fullName = (data.personalInfo?.name || `${data.personalInfo?.firstName || ''} ${data.personalInfo?.lastName || ''}`.trim()).trim();
     // HTML şablonu, sohbet sırasında eklenen yeni bölümleri (projects, languages vb.)
     // dinamik olarak render edebilir.
@@ -62,14 +68,14 @@ const generateCvHtml = (data) => {
     <body>
     <div class="page">
         ${fullName ? `<div class="header"><h1 class="name">${fullName}</h1><p class="contact-info">${data.personalInfo?.email || ''} | ${data.personalInfo?.phone || ''} | ${data.personalInfo?.location || ''}</p></div>` : ''}
-        ${data.summary ? `<div class="section"><h2 class="section-title">Summary</h2><p>${data.summary}</p></div>` : ''}
-        ${data.experience && data.experience.length > 0 ? `<div class="section"><h2 class="section-title">Experience</h2>${data.experience.map(exp => `<div class="item-container"><div class="item-content"><h3>${exp.title}</h3><div class="sub-header">${exp.company} | ${exp.location}</div><ul>${(exp.description || '').split('\\n').filter(d => d.trim() !== '').map(d => `<li>${d.replace(/^- /, '')}</li>`).join('')}</ul></div><div class="item-date">${exp.date || ''}</div></div>`).join('')}</div>` : ''}
-        ${data.education && data.education.length > 0 ? `<div class="section"><h2 class="section-title">Education</h2>${data.education.map(edu => `<div class="item-container"><div class="item-content"><h3>${edu.degree}</h3><p>${edu.institution}</p></div><div class="item-date">${edu.date || ''}</div></div>`).join('')}</div>` : ''}
-        ${data.skillsByCategory && data.skillsByCategory.length > 0 ? `<div class="section"><h2 class="section-title">Skills</h2><div class="skills-container">${data.skillsByCategory.map(cat => `<div class="skills-category"><h4>${cat.category}</h4><ul>${(cat.skills || []).map(s => `<li>${s}</li>`).join('')}</ul></div>`).join('')}</div></div>` : ''}
-        ${data.projects && data.projects.length > 0 ? `<div class="section projects"><h2 class="section-title">Projects</h2>${data.projects.map(proj => `<div><h3>${proj.name}</h3><p>${proj.description}</p></div>`).join('')}</div>` : ''}
-        ${data.languages && data.languages.length > 0 ? `<div class="section"><h2 class="section-title">Languages</h2>${data.languages.map(lang => `<p>${lang.language} (${lang.proficiency})</p>`).join('')}</div>` : ''}
-        ${data.certificates && data.certificates.length > 0 ? `<div class="section"><h2 class="section-title">Certificates</h2>${data.certificates.map(cert => `<p>${cert}</p>`).join('')}</div>` : ''}
-        ${data.analysis ? `<div class="section"><h2 class="section-title">AI Analysis</h2><p>${data.analysis}</p></div>` : ''}
+        ${data.summary ? `<div class="section"><h2 class="section-title">${t.summary}</h2><p>${data.summary}</p></div>` : ''}
+        ${data.experience && data.experience.length > 0 ? `<div class="section"><h2 class="section-title">${t.experience}</h2>${data.experience.map(exp => `<div class="item-container"><div class="item-content"><h3>${exp.title || ''}</h3><div class="sub-header">${exp.company || ''} | ${exp.location || ''}</div><ul>${(exp.description || '').split('\\n').filter(d => d.trim() !== '').map(d => `<li>${d.replace(/^- /, '')}</li>`).join('')}</ul></div><div class="item-date">${exp.date || ''}</div></div>`).join('')}</div>` : ''}
+        ${data.education && data.education.length > 0 ? `<div class="section"><h2 class="section-title">${t.education}</h2>${data.education.map(edu => `<div class="item-container"><div class="item-content"><h3>${edu.degree || ''}</h3><p>${edu.institution || ''}</p></div><div class="item-date">${edu.date || ''}</div></div>`).join('')}</div>` : ''}
+        ${data.skillsByCategory && data.skillsByCategory.length > 0 ? `<div class="section"><h2 class="section-title">${t.skills}</h2><div class="skills-container">${data.skillsByCategory.map(cat => `<div class="skills-category"><h4>${cat.category || ''}</h4><ul>${(cat.skills || []).map(s => `<li>${s}</li>`).join('')}</ul></div>`).join('')}</div></div>` : ''}
+        ${data.projects && data.projects.length > 0 ? `<div class="section projects"><h2 class="section-title">${t.projects}</h2>${data.projects.map(proj => `<div><h3>${proj.name || ''}</h3><p>${proj.description || ''}</p></div>`).join('')}</div>` : ''}
+        ${data.languages && data.languages.length > 0 ? `<div class="section"><h2 class="section-title">${t.languages}</h2>${data.languages.map(lang => `<p>${(lang.language || '')} ${lang.proficiency ? '(' + lang.proficiency + ')' : ''}</p>`).join('')}</div>` : ''}
+        ${data.certificates && data.certificates.length > 0 ? `<div class="section"><h2 class="section-title">${t.certificates}</h2>${data.certificates.map(cert => `<p>${cert || ''}</p>`).join('')}</div>` : ''}
+        ${data.analysis ? `<div class="section"><h2 class="section-title">${t.analysis}</h2><p>${data.analysis}</p></div>` : ''}
     </div>
     </body>
     </html>`;
@@ -81,11 +87,11 @@ const generateCvHtml = (data) => {
  * @param {object} data - CV verilerini içeren JSON nesnesi.
  * @returns {Promise<Buffer>} - Oluşturulan PDF dosyasının Buffer'ı.
  */
-async function createPdf(data) {
+async function createPdf(data, language = 'en') {
     let browser = null;
     logStep("PDF oluşturma süreci başladı.");
     try {
-        const htmlContent = generateCvHtml(data);
+        const htmlContent = generateCvHtml(data, language);
         let launchOptions;
 
         if (IS_PRODUCTION) {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "homepage": ".",
   "dependencies": {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -178,6 +178,30 @@ input[type="file"] { display: none; }
 @keyframes bob { 0%, 80%, 100% { transform: scale(0); } 40% { transform: scale(1.0); } }
 .error-text { color: #d93025; margin-top: 1rem; text-align: center; font-weight: 500; }
 
+.loading-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(255,255,255,0.7);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 9999;
+}
+
+.spinner {
+    border: 4px solid #f3f3f3;
+    border-top: 4px solid var(--primary-color);
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }
+
 /* Mobil Uyumluluk */
 @media (max-width: 768px) {
     .app-container { height: 100%; padding: 0; }

--- a/package2.json
+++ b/package2.json
@@ -1,6 +1,6 @@
 {
   "name": "cvbuilder-monorepo",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "private": true,
   "workspaces": [
     "frontend",


### PR DESCRIPTION
## Summary
- store uploaded and generated files by session
- open generated PDFs in a new tab on mobile
- show spinner overlay while waiting
- localize PDF section headers based on selected language
- simplify AI questions
- bump package versions

## Testing
- `npm test --silent` in frontend
- `npm test --silent` in backend

------
https://chatgpt.com/codex/tasks/task_e_688d260e13648327ae1c78d2b4f3edc3