### PR TITLE
Improve PDF download and language handling

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "dependencies": {
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -191,16 +191,21 @@ input[type="file"] { display: none; }
     z-index: 9999;
 }
 
-.spinner {
-    border: 4px solid #f3f3f3;
-    border-top: 4px solid var(--primary-color);
-    border-radius: 50%;
-    width: 40px;
-    height: 40px;
-    animation: spin 1s linear infinite;
+.dot-spinner {
+    display: flex;
+    align-items: center;
+    gap: 8px;
 }
-
-@keyframes spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }
+.dot-spinner div {
+    width: 10px;
+    height: 10px;
+    background-color: var(--primary-color);
+    border-radius: 50%;
+    animation: dotBounce 0.6s infinite alternate;
+}
+.dot-spinner div:nth-child(2) { animation-delay: 0.2s; }
+.dot-spinner div:nth-child(3) { animation-delay: 0.4s; }
+@keyframes dotBounce { from { transform: translateY(0); opacity: 1; } to { transform: translateY(-6px); opacity: 0.3; } }
 
 /* Mobil Uyumluluk */
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- tweak spinner animation for a smoother waiting indicator
- parse language answers from AI questions when creating the final CV
- always trigger a direct PDF download instead of opening in a new tab
- update package-lock.json version to match package.json

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests` in `frontend`
- `npm test --silent -- --watchAll=false --passWithNoTests` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_688d3ba57b1c8327839f69457ad13cc2