### PR TITLE
fix: extend upload timeout and limit loading animation

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -178,27 +178,16 @@ input[type="file"] { display: none; }
 @keyframes bob { 0%, 80%, 100% { transform: scale(0); } 40% { transform: scale(1.0); } }
 .error-text { color: #d93025; margin-top: 1rem; text-align: center; font-weight: 500; }
 
-.loading-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: rgba(255,255,255,0.6);
-    backdrop-filter: blur(4px);
-    -webkit-backdrop-filter: blur(4px);
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    z-index: 9999;
-}
 
-.ring-spinner {
-    width: 40px;
-    height: 40px;
-    border: 4px solid var(--primary-color);
+.button-spinner {
+    width: 16px;
+    height: 16px;
+    border: 2px solid var(--primary-color);
     border-bottom-color: transparent;
     border-radius: 50%;
+    display: inline-block;
+    margin-right: 8px;
+    vertical-align: middle;
     animation: ringSpin 0.8s linear infinite;
 }
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -67,7 +67,7 @@ function App() {
     setLoadingMessage(t('uploadingButtonLabel')); setError('');
     const formData = new FormData(); formData.append('cv', file);
     try {
-      const res = await axios.post(`${API_BASE_URL}/api/extract-raw`, formData, { timeout: 45000 });
+      const res = await axios.post(`${API_BASE_URL}/api/extract-raw`, formData, { timeout: 120000 });
       setSessionId(res.data.sessionId);
       startScriptedQuestions(res.data.parsedData);
     } catch (err) {
@@ -237,11 +237,6 @@ function App() {
 
   return (
     <div className="app-container">
-      {isLoading && (
-        <div className="loading-overlay">
-          <div className="ring-spinner"></div>
-        </div>
-      )}
       {step === 'upload' ? (
         <div className="upload-step fade-in">
           <div className="settings-bar"><ThemeSwitcher theme={theme} setTheme={setTheme} /><LanguageSwitcher /></div>
@@ -250,7 +245,10 @@ function App() {
           <p>{t('subtitle')}</p>
           <div className="language-controls"><div className="control-group"><label htmlFor="cv-lang">{t('cvLanguageLabel')}</label><select id="cv-lang" value={cvLanguage} onChange={e => setCvLanguage(e.target.value)} disabled={isLoading}><option value="tr">Türkçe</option><option value="en">English</option></select></div></div>
           <input type="file" id="file-upload" ref={fileInputRef} onChange={handleInitialParse} disabled={isLoading} accept=".pdf,.docx" style={{ display: 'none' }} />
-          <label htmlFor="file-upload" className={`file-upload-label ${isLoading ? 'disabled' : ''}`}>{isLoading ? loadingMessage : t('uploadButtonLabel')}</label>
+          <label htmlFor="file-upload" className={`file-upload-label ${isLoading ? 'disabled' : ''}`}>
+            {isLoading && <span className="button-spinner"></span>}
+            {isLoading ? loadingMessage : t('uploadButtonLabel')}
+          </label>
           {error && <p className="error-text">{error}</p>}
           <footer>{`${t('footerText')} - v${packageJson.version}`}</footer>
         </div>
@@ -264,6 +262,7 @@ function App() {
               {step !== 'final' && (<> <button onClick={() => processNextStep()} disabled={isLoading || !currentAnswer} className="reply-button">{t('answerButton')} <SendIcon /></button> <button onClick={() => processNextStep(true)} disabled={isLoading} className="secondary">{t('skipButton')}</button> </>)}
               {(step === 'final' || questionQueue.length === 0) && (
                 <button onClick={handleGeneratePdf} disabled={isLoading || !cvData} className="primary">
+                  {isLoading && <span className="button-spinner"></span>}
                   {isLoading ? loadingMessage : t('finishButton')}
                 </button>
               )}

--- a/frontend/src/components/UploadStep.js
+++ b/frontend/src/components/UploadStep.js
@@ -37,8 +37,9 @@ const UploadStep = ({ onFileSelect, cvLanguage, setCvLanguage, isLoading, loadin
         accept=".pdf,.docx"
         style={{ display: 'none' }}
       />
-      <label htmlFor="file-upload" className={`file-upload-label ${isLoading ? 'disabled' : ''}`}>
-        {isLoading ? loadingMessage : t('uploadButtonLabel')}
+      <label htmlFor="file-upload" className={`file-upload-label ${isLoading ? 'disabled' : ''}`}> 
+        {isLoading && <span className="button-spinner"></span>}
+        {isLoading ? loadingMessage : t('uploadButtonLabel')} 
       </label>
       {error && <p className="error-text">{error}</p>}
       <footer>{`${t('footerText')} - v${packageJson.version}`}</footer>


### PR DESCRIPTION
## Summary
- extend initial PDF extraction timeout to avoid false upload failures
- show loading spinner only within action buttons instead of a global overlay

## Testing
- `cd frontend && CI=true npm test -- --passWithNoTests --silent`
- `cd backend && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688dd511cbe483279d5f1e1171cbe2b6