### PR TITLE
feat: open cover letter pdf in new tab

### DIFF
--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -12,6 +12,7 @@
   "answerButton": "Send",
   "skipButton": "Skip Question",
   "finishButton": "Create & Download CV",
+  "downloadCoverLetterButton": "Download Cover Letter",
   "generatingPdfButton": "Finalizing PDF...",
   "finalMessage": "Your CV has been successfully prepared and ready to download!",
   "coverLetterIntro": "Here is a draft for a compelling cover letter introduction based on your new CV. You can copy and adapt it for your job applications:",

--- a/frontend/src/locales/tr/translation.json
+++ b/frontend/src/locales/tr/translation.json
@@ -12,6 +12,7 @@
   "answerButton": "Gönder",
   "skipButton": "Soruyu Atla",
   "finishButton": "CV'mi Oluştur & İndir",
+  "downloadCoverLetterButton": "Ön Yazıyı İndir",
   "generatingPdfButton": "PDF Sonlandırılıyor...",
   "coverLetterIntro": "İşte yeni CV'nize dayalı, ilgi çekici bir ön yazı girişi taslağı. Bunu kopyalayıp iş başvurularınız için uyarlayabilirsiniz:",
   "finalMessage": "CV'niz başarıyla oluşturuldu ve indirmeye hazır!",


### PR DESCRIPTION
## Summary
- open cover letter PDF in a new tab and let users download it later
- add download button and translations for cover letter

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_688de20bf0d48327bc96a20f4ce6485f