### PR TITLE
Improve AI prompts, add CV scoring and UI tweaks

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "CV Builder backend",
   "main": "server.js",
   "scripts": {

--- a/backend/routes/api.js
+++ b/backend/routes/api.js
@@ -29,6 +29,18 @@ router.post('/generate-ai-questions', async (req, res) => {
   } catch (error) { console.error("Adım 2 Hatası:", error); res.status(500).send({ message: 'AI soruları üretilemedi.' }); }
 });
 
+// CV'yi puanlayan yeni uç nokta
+router.post('/score-cv', async (req, res) => {
+  try {
+    const { cvData, appLanguage } = req.body;
+    const result = await aiService.scoreCvData(cvData, appLanguage);
+    res.json(result);
+  } catch (error) {
+    console.error("CV Puanlama Hatası:", error);
+    res.status(500).send({ message: 'CV puanı alınamadı.' });
+  }
+});
+
 // ADIM 3: Final PDF'i Oluştur (Mevcut ve Doğru)
 router.post('/finalize-and-create-pdf', async (req, res) => {
   try {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.2.0",
+      "version": "1.2.2",
       "dependencies": {
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "homepage": ".",
   "dependencies": {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -203,18 +203,53 @@ input[type="file"] { display: none; }
 
 
 .button-spinner {
-    width: 16px;
-    height: 16px;
-    border: 2px solid var(--primary-color);
-    border-bottom-color: transparent;
-    border-radius: 50%;
     display: inline-block;
+    position: relative;
+    width: 16px;
+    height: 8px;
     margin-right: 8px;
     vertical-align: middle;
-    animation: ringSpin 1.5s linear infinite;
 }
 
-@keyframes ringSpin { to { transform: rotate(360deg); } }
+.button-spinner::before,
+.button-spinner::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--primary-color);
+    animation: buttonBounce 0.6s infinite alternate;
+}
+
+.button-spinner { background: var(--primary-color); border-radius: 50%; animation: buttonBounce 0.6s infinite alternate; }
+.button-spinner::before { left: -8px; animation-delay: -0.2s; }
+.button-spinner::after { left: 8px; animation-delay: 0.2s; }
+
+@keyframes buttonBounce { to { transform: translateY(-4px); } }
+
+.demo-badge {
+    background-color: var(--primary-color);
+    color: #fff;
+    font-size: 0.75rem;
+    padding: 2px 6px;
+    border-radius: 4px;
+    margin-left: 8px;
+    vertical-align: middle;
+}
+
+.button-group button.blue {
+    background-color: #1e88e5;
+    color: #fff;
+}
+.button-group button.blue:hover {
+    background-color: #1565c0;
+}
+
+.button-group button.highlight {
+    box-shadow: 0 0 10px var(--primary-color);
+}
 
 /* Mobil Uyumluluk */
 @media (max-width: 768px) {

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1,5 +1,5 @@
 {
-  "mainTitle": "AI CV Guide",
+  "mainTitle": "AI-assisted CV Guide",
   "subtitle": "Recreate your CV from scratch with our AI-powered assistant.",
   "cvLanguageLabel": "Target CV Language:",
   "uploadButtonLabel": "Upload Your CV",
@@ -19,6 +19,8 @@
   "generatingPdfButton": "Finalizing PDF...",
   "finalMessage": "We've gathered the essential feedback for your CV. How would you like to proceed?",
   "improveButton": "Perfect My CV",
+  "demoBadge": "Demo",
+  "cvScore": "Your CV scored {{score}}/100.",
   "coverLetterIntro": "Here is a draft for a compelling cover letter introduction based on your new CV. You can copy and adapt it for your job applications:",
   "errorOccurred": "An error occurred. Please try again.",
   "chatError": "An error occurred during the chat.",

--- a/frontend/src/locales/tr/translation.json
+++ b/frontend/src/locales/tr/translation.json
@@ -1,5 +1,5 @@
 {
-  "mainTitle": "Yapay Zeka CV Rehberi",
+  "mainTitle": "AI destekli CV Rehberi",
   "subtitle": "Yapay zeka destekli asistan ile CV'nizi baştan yaratın.",
   "cvLanguageLabel": "Hedef CV Dili:",
   "uploadButtonLabel": "CV Dosyanızı Yükleyin",
@@ -20,6 +20,8 @@
   "coverLetterIntro": "İşte yeni CV'nize dayalı, ilgi çekici bir ön yazı girişi taslağı. Bunu kopyalayıp iş başvurularınız için uyarlayabilirsiniz:",
   "finalMessage": "CV’niz için gerekli geri bildirimler alındı. Nasıl devam edelim?",
   "improveButton": "CV’mi mükemmelleştir",
+  "demoBadge": "Demo",
+  "cvScore": "CV'niz {{score}}/100 puan aldı.",
   "errorOccurred": "Bir hata oluştu. Lütfen tekrar deneyin.",
   "chatError": "Sohbet sırasında bir hata oluştu.",
   "pdfError": "PDF oluşturulurken bir hata oluştu.",

--- a/package2.json
+++ b/package2.json
@@ -1,6 +1,6 @@
 {
   "name": "cvbuilder-monorepo",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "workspaces": [
     "frontend",


### PR DESCRIPTION
## Summary
- Refined question generation to use observation-style requests and strengthened final CV prompt with user addition integration.
- Added CV scoring endpoint and frontend logic to display scores and emphasize actions based on results.
- Updated UI with blue cover-letter download button, new spinner, demo badge, and revised translations.
- Bumped package versions.

## Testing
- `CI=true npm test --prefix frontend` (fails: No tests found, exiting with code 1)
- `npm test --prefix backend` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_688e1f746f888327b6fd414d4fc6b61c