### PR TITLE
feat: improve AI question generation and update versions

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "CV Builder backend",
   "main": "server.js",
   "scripts": {

--- a/backend/routes/api.js
+++ b/backend/routes/api.js
@@ -22,7 +22,7 @@ router.post('/extract-raw', fileService.upload.single('cv'), async (req, res) =>
 // ADIM 2: AI Sorularını Üret (Mevcut ve Doğru)
 router.post('/generate-ai-questions', async (req, res) => {
   try {
-    const { cvData, appLanguage, askedQuestions = [], maxQuestions = 3 } = req.body; // sessionId can be sent but is optional
+    const { cvData, appLanguage, askedQuestions = [], maxQuestions = 4 } = req.body; // sessionId can be sent but is optional
     logStep("ADIM 2: AI için stratejik sorular üretiliyor.");
     const questionsData = await aiService.generateAiQuestions(cvData, appLanguage, askedQuestions, maxQuestions);
     res.json(questionsData);

--- a/backend/services/aiService.js
+++ b/backend/services/aiService.js
@@ -34,20 +34,20 @@ const getExtractionPrompt = (cvText, template) => `
  * Yapay zekaya, mevcut CV'yi analiz edip en önemli eksikleri bulmasını ve bu eksikler için
  * belirtilen dilde sorular üretmesini söyler. DİL KURALI ÇOK KESİNDİR.
  */
-const getAiQuestionsPrompt = (cvData, appLanguageCode, askedQuestions = [], maxQuestions = 3) => {
+const getAiQuestionsPrompt = (cvData, appLanguageCode, askedQuestions = [], maxQuestions = 4) => {
   const appLanguage = normalizeLanguage(appLanguageCode);
   return `
   You are a helpful career assistant. Carefully inspect the CV JSON below and identify up to ${maxQuestions} basic pieces of information that are missing or incomplete.
 
   **RULES:**
   1. **LANGUAGE LOCK:** Write every question only in '${appLanguage}'.
-  2. **BASIC INFO:** Focus on core CV details such as job titles, dates, education, key skills, or contact information. Avoid diving into detailed coaching or advanced strategies.
+  2. **BASIC INFO:** Give priority to these core CV sections: summary, references, education, work experience, certifications, projects, languages, and skills.
   3. **NO DUPLICATES:** Skip anything already filled in and do not repeat any of these questions: ${askedQuestions.join(' | ')}.
-  4. **LIMIT:** Maximum ${maxQuestions} short questions.
-  5. **TONE:** Phrase each item as an observation followed by a polite request. Example: "Education section appears empty; could you share it?".
+  4. **ORDER:** Start with the most important missing section and proceed in descending importance.
+  5. **LIMIT:** Maximum ${maxQuestions} short questions.
+  6. **TONE:** Phrase each item as an observation followed by a polite request, using the correct section name.
 
-  Your final output MUST be a single JSON object with the key "questions", containing an array of strings.
-  Example JSON output: { "questions": ["Education section appears empty; could you share it?", "Question 2 in ${appLanguage}?"] }
+  Your final output MUST be a single JSON object with the key "questions", containing an array of strings written in ${appLanguage}.
 
   CV Data to analyze (in JSON format):
   ${JSON.stringify(cvData)}
@@ -120,7 +120,7 @@ async function extractRawCvData(cvText, template) {
   return JSON.parse(response.choices[0].message.content);
 }
 
-async function generateAiQuestions(cvData, appLanguage, askedQuestions = [], maxQuestions = 3) {
+async function generateAiQuestions(cvData, appLanguage, askedQuestions = [], maxQuestions = 4) {
   logStep("AI için Stratejik Sorular Üretiliyor.");
   const response = await openai.chat.completions.create({
     model: 'gpt-4o-mini',

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": true,
   "homepage": ".",
   "dependencies": {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -85,7 +85,7 @@ function App() {
     }
   };
 
-  const fetchAiQuestions = async (currentData, maxQuestions = 3) => {
+  const fetchAiQuestions = async (currentData, maxQuestions = 4) => {
     setLoadingMessage("AI CV'nizi Analiz Ediyor...");
     try {
       const res = await axios.post(`${API_BASE_URL}/api/generate-ai-questions`, {

--- a/frontend/src/services/apiService.js
+++ b/frontend/src/services/apiService.js
@@ -18,7 +18,7 @@ export async function extractRawData(file) {
 /**
  * Mevcut CV verisine göre AI'dan stratejik sorular ister.
  */
-export async function fetchAiQuestions(cvData, appLanguage, askedQuestions = [], maxQuestions = 3) {
+export async function fetchAiQuestions(cvData, appLanguage, askedQuestions = [], maxQuestions = 4) {
   const response = await axios.post(`${API_BASE_URL}/api/generate-ai-questions`, {
     cvData,
     appLanguage,


### PR DESCRIPTION
## Summary
- ensure AI questions respect the interface language, focus on key CV areas, and order by priority
- allow up to four follow-up questions
- bump backend and frontend versions

## Testing
- `npm test` (backend) *(fails: Missing script)*
- `CI=true npm test` (frontend) *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_688e36992784832783e93c0c873b5e59