### PR TITLE
Align demo badge with main title on upload step

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -131,7 +131,15 @@ footer {
     display: flex;
     flex-direction: column;
 }
-.upload-step h1 { margin-top: 0; font-size: 2rem; color: var(--text-primary-color); font-family: 'Playfair Display', serif; }
+.upload-step h1 {
+    margin-top: 0;
+    font-size: 2rem;
+    color: var(--text-primary-color);
+    font-family: 'Playfair Display', serif;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
 .upload-step p { color: var(--text-secondary-color); }
 .language-controls { display: flex; justify-content: center; margin: 2rem 0; gap: 1rem; }
 .control-group { display: flex; flex-direction: column; align-items: center; gap: 0.5rem; }
@@ -243,7 +251,6 @@ input[type="file"] { display: none; }
     font-size: 0.65rem;
     padding: 1px 4px;
     border-radius: 4px;
-    margin-left: 8px;
     vertical-align: middle;
     position: relative;
     top: -2px;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -294,7 +294,7 @@ function App() {
         <div className="upload-step fade-in">
           <div className="settings-bar"><ThemeSwitcher theme={theme} setTheme={setTheme} /><LanguageSwitcher /></div>
           <Logo />
-          <h1>{t('mainTitle')} <span className="demo-badge">{t('demoBadge')}</span></h1>
+          <h1><span>{t('mainTitle')}</span><span className="demo-badge">{t('demoBadge')}</span></h1>
           <p>{t('subtitle')}</p>
           <div className="language-controls"><div className="control-group"><label htmlFor="cv-lang">{t('cvLanguageLabel')}</label><select id="cv-lang" value={cvLanguage} onChange={e => setCvLanguage(e.target.value)} disabled={isLoading}><option value="tr">Türkçe</option><option value="en">English</option></select></div></div>
           <input type="file" id="file-upload" ref={fileInputRef} onChange={handleInitialParse} disabled={isLoading} accept=".pdf,.docx" style={{ display: 'none' }} />


### PR DESCRIPTION
## Summary
- Keep "Demo" badge inline with the main header so it no longer drops to a new line
- Simplify badge spacing using flex layout

## Testing
- `npm test --prefix frontend -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_688e3e3421a48327ac274e9ad1d196e2