### PR TITLE
Improve review actions and error handling

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -133,7 +133,7 @@ footer {
 }
 .upload-step h1 {
     margin-top: 0;
-    font-size: 2rem;
+    font-size: 1.4rem;
     color: var(--text-primary-color);
     font-family: 'Playfair Display', serif;
     display: inline-flex;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -104,13 +104,21 @@ function App() {
         setConversation(prev => [...prev, { type: 'ai', text: aiQuestions[0].key }]);
       } else {
         setCanRefine(false);
-        setConversation(prev => [...prev, { type: 'ai', text: t('finalMessage') }]);
+        setConversation(prev => [
+          ...prev,
+          { type: 'ai', text: t('noContentError') },
+          { type: 'ai', text: t('finalMessage') }
+        ]);
         setStep('review');
         scoreCv(cvData);
       }
     } catch (err) {
       setError(err.response?.data?.message || t('chatError'));
-      setConversation(prev => [...prev, { type: 'ai', text: t('finalMessage') }]); // Hata durumunda da review adımına geç
+      setConversation(prev => [
+        ...prev,
+        { type: 'ai', text: t('chatError') },
+        { type: 'ai', text: t('finalMessage') }
+      ]);
       setStep('review');
       scoreCv(cvData);
     } finally {
@@ -187,6 +195,7 @@ function App() {
   const handleGeneratePdf = async () => {
     if (!cvData || hasGeneratedPdf) { return; }
 
+    setConversation(prev => [...prev, { type: 'user', text: t('generateCvButton') }]);
     setLoadingMessage(t('generatingPdfButton'));
     setError('');
     setCoverLetterPdfUrl('');
@@ -265,6 +274,7 @@ function App() {
 
   const handleRefine = () => {
     if (!cvData) return;
+    setConversation(prev => [...prev, { type: 'user', text: t('improveButton') }]);
     fetchAiQuestions(cvData, 2);
   };
 

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -23,7 +23,8 @@
   "cvScore": "Your CV scored {{score}}/100.",
   "coverLetterIntro": "Here is a draft for a compelling cover letter introduction based on your new CV. You can copy and adapt it for your job applications:",
   "errorOccurred": "An error occurred. Please try again.",
-  "chatError": "An error occurred during the chat.",
-  "pdfError": "An error occurred while creating the PDF.",
+    "chatError": "An error occurred during the chat.",
+    "noContentError": "I couldn't extract meaningful information from the uploaded CV. Please try another file.",
+    "pdfError": "An error occurred while creating the PDF.",
   "footerText": "Developed by Mustafa Evleksiz"
 }

--- a/frontend/src/locales/tr/translation.json
+++ b/frontend/src/locales/tr/translation.json
@@ -23,7 +23,8 @@
   "demoBadge": "Demo",
   "cvScore": "CV'niz {{score}}/100 puan aldı.",
   "errorOccurred": "Bir hata oluştu. Lütfen tekrar deneyin.",
-  "chatError": "Sohbet sırasında bir hata oluştu.",
-  "pdfError": "PDF oluşturulurken bir hata oluştu.",
+    "chatError": "Sohbet sırasında bir hata oluştu.",
+    "noContentError": "Yüklenen CV'den anlamlı bilgi çıkarılamadı. Lütfen farklı bir dosya deneyin.",
+    "pdfError": "PDF oluşturulurken bir hata oluştu.",
   "footerText": "Mustafa Evleksiz tarafından geliştirilmiştir"
 }


### PR DESCRIPTION
## Summary
- Reduce header font size for a more compact "AI-assisted CV Guide" banner
- Treat CV generate/perfect actions as chat messages
- Show explicit feedback when uploaded CV lacks usable content

## Testing
- `cd frontend && npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_688e450232d8832780b72141005d5a9d