### PR TITLE
Add feedback logging and UI

### DIFF
--- a/backend/routes/api.js
+++ b/backend/routes/api.js
@@ -103,4 +103,18 @@ router.post('/generate-cover-letter-pdf', async (req, res) => {
 // --- YENİ BÖLÜMÜN SONU ---
 
 
+// Feedback toplama
+router.post('/feedback', (req, res) => {
+  try {
+    const { name, email, description, language, theme, deviceInfo, sessionId } = req.body;
+    const ip = req.headers['x-forwarded-for'] || req.connection?.remoteAddress || req.ip;
+    const text = `Name: ${name || ''}\nEmail: ${email || ''}\nDescription: ${description}\nIP: ${ip}\nDevice: ${deviceInfo}\nLanguage: ${language}\nTheme: ${theme}\nSession: ${sessionId || ''}`;
+    fileService.saveFeedback(text);
+    res.status(200).json({ message: 'Feedback kaydedildi.' });
+  } catch (error) {
+    console.error('Feedback Hatası:', error);
+    res.status(500).send({ message: 'Feedback kaydedilemedi.' });
+  }
+});
+
 module.exports = router;

--- a/backend/services/aiService.js
+++ b/backend/services/aiService.js
@@ -122,13 +122,23 @@ async function extractRawCvData(cvText, template) {
 
 async function generateAiQuestions(cvData, appLanguage, askedQuestions = [], maxQuestions = 4) {
   logStep("AI için Stratejik Sorular Üretiliyor.");
-  const response = await openai.chat.completions.create({
-    model: 'gpt-4o-mini',
-    messages: [{ role: 'user', content: getAiQuestionsPrompt(cvData, appLanguage, askedQuestions, maxQuestions) }],
-    response_format: { type: "json_object" },
-  });
-  logStep("AI Soruları Üretildi.");
-  return JSON.parse(response.choices[0].message.content);
+  try {
+    const response = await openai.chat.completions.create({
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user', content: getAiQuestionsPrompt(cvData, appLanguage, askedQuestions, maxQuestions) }],
+      response_format: { type: "json_object" },
+    });
+    const content = response.choices[0].message.content;
+    logStep(`AI Soruları Üretildi: ${content}`);
+    return JSON.parse(content);
+  } catch (error) {
+    if (error.response?.data) {
+      logStep(`AI Soruları Hatası: ${JSON.stringify(error.response.data)}`);
+    } else {
+      logStep(`AI Soruları Hatası: ${error.message}`);
+    }
+    throw error;
+  }
 }
 
 // Bu fonksiyon artık 'analysis' üretmiyor, sadece CV'yi finalize ediyor.

--- a/backend/services/fileService.js
+++ b/backend/services/fileService.js
@@ -88,6 +88,18 @@ function getTemplate() {
   return JSON.parse(fs.readFileSync(templatePath, 'utf8'));
 }
 
+function saveFeedback(text) {
+  const feedbackDir = path.join(dataDir, 'feedbacks');
+  if (!fs.existsSync(feedbackDir)) {
+    fs.mkdirSync(feedbackDir, { recursive: true });
+  }
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const filePath = path.join(feedbackDir, `Feedback_${timestamp}.txt`);
+  fs.writeFileSync(filePath, text);
+  logStep(`Feedback kaydedildi: ${filePath}`);
+  return filePath;
+}
+
 // Bu fonksiyonları dışa aktarıyoruz ki api.js tarafından kullanılabilsin.
 module.exports = {
   upload,
@@ -95,5 +107,6 @@ module.exports = {
   saveBuffer,
   createSession,
   getTextFromFile,
-  getTemplate
+  getTemplate,
+  saveFeedback
 };

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -116,6 +116,67 @@ body {
 .language-switcher button.active { border-color: var(--primary-color); transform: scale(1.1); }
 .theme-switcher:hover { border-color: var(--primary-color); }
 .language-switcher button svg { width: 100%; height: 100%; display: block; object-fit: cover; }
+.feedback-icon {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    border: 1px solid var(--border-color);
+    background-color: var(--surface-color);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    color: var(--text-secondary-color);
+    transition: border-color 0.2s ease-in-out;
+}
+.feedback-icon:hover { border-color: var(--primary-color); }
+
+/* Feedback modal */
+.feedback-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0,0,0,0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+.feedback-modal .modal-content {
+    background: var(--surface-color);
+    padding: 1rem;
+    border-radius: 8px;
+    width: 90%;
+    max-width: 400px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+.feedback-modal input,
+.feedback-modal textarea {
+    width: 100%;
+    padding: 0.5rem;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    background: var(--background-color);
+    color: var(--text-primary-color);
+}
+.feedback-modal textarea { min-height: 80px; resize: vertical; }
+.feedback-modal button {
+    align-self: flex-end;
+    background: var(--primary-color);
+    color: #fff;
+    border: none;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    cursor: pointer;
+}
+.feedback-modal button:disabled {
+    background: var(--secondary-color);
+    cursor: not-allowed;
+}
 footer {
     text-align: center;
     padding: 0.5rem 0;
@@ -143,8 +204,9 @@ footer {
     font-size: 1.4rem;
     color: var(--text-primary-color);
     font-family: 'Playfair Display', serif;
-    display: inline-flex;
+    display: flex;
     align-items: center;
+    justify-content: center;
     gap: 8px;
 }
 .upload-step p { color: var(--text-secondary-color); }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import Logo from './components/Logo';
 import LanguageSwitcher from './components/LanguageSwitcher';
 import ThemeSwitcher from './components/ThemeSwitcher';
+import Feedback from './components/Feedback';
 import packageJson from '../package.json';
 import './App.css';
 
@@ -300,9 +301,9 @@ function App() {
 
   return (
     <div className="app-container">
-      {step === 'upload' ? (
+          {step === 'upload' ? (
         <div className="upload-step fade-in">
-          <div className="settings-bar"><ThemeSwitcher theme={theme} setTheme={setTheme} /><LanguageSwitcher /></div>
+          <div className="settings-bar"><Feedback sessionId={sessionId} language={i18n.language} theme={theme} /><ThemeSwitcher theme={theme} setTheme={setTheme} /><LanguageSwitcher /></div>
           <Logo />
           <h1><span>{t('mainTitle')}</span><span className="demo-badge">{t('demoBadge')}</span></h1>
           <p>{t('subtitle')}</p>
@@ -317,7 +318,7 @@ function App() {
         </div>
       ) : (
         <div className="chat-step fade-in">
-          <div className="chat-header"><Logo /><div className="settings-bar"><ThemeSwitcher theme={theme} setTheme={setTheme} /><LanguageSwitcher /></div></div>
+          <div className="chat-header"><Logo /><div className="settings-bar"><Feedback sessionId={sessionId} language={i18n.language} theme={theme} /><ThemeSwitcher theme={theme} setTheme={setTheme} /><LanguageSwitcher /></div></div>
           <div className="chat-window" ref={chatContainerRef}>{conversation.map((msg, index) => msg.type === 'typing' ? <TypingIndicator key={index} /> : <div key={index} className={`message ${msg.type}`}>{msg.text}</div>)}</div>
           <div className="chat-input-area">
             {(step === 'scriptedQuestions' || step === 'aiQuestions') && (

--- a/frontend/src/components/Feedback.js
+++ b/frontend/src/components/Feedback.js
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+
+const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:5001';
+
+export default function Feedback({ sessionId, language, theme }) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [desc, setDesc] = useState('');
+  const [sending, setSending] = useState(false);
+  const [sent, setSent] = useState(false);
+
+  const handleSubmit = async () => {
+    if (desc.trim().length < 5) return;
+    setSending(true);
+    try {
+      await axios.post(`${API_BASE_URL}/api/feedback`, {
+        name,
+        email,
+        description: desc,
+        language,
+        theme,
+        deviceInfo: navigator.userAgent,
+        sessionId,
+      });
+      setSent(true);
+      setTimeout(() => {
+        setOpen(false);
+        setSent(false);
+        setName('');
+        setEmail('');
+        setDesc('');
+      }, 2000);
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="feedback-icon" title="feedback ver" onClick={() => setOpen(true)}>
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+          <path d="M8 0a8 8 0 1 0 4.906 14.32L16 16l-1.68-3.094A8 8 0 0 0 8 0zm0 1.5a6.5 6.5 0 1 1 0 13 6.5 6.5 0 0 1 0-13z"/>
+        </svg>
+      </div>
+      {open && (
+        <div className="feedback-modal">
+          <div className="modal-content">
+            {sent ? (
+              <p>Geri bildirimin için teşekkürler!</p>
+            ) : (
+              <>
+                <p>Hata mı aldın/ Bir fikrin mi var? Geri bildirimin çok değerli.<br/>Uygulamamı geliştirmeme yardımcı olacak.</p>
+                <input placeholder="İsim" value={name} onChange={e => setName(e.target.value)} />
+                <input placeholder="Mail (Opsiyonel)" value={email} onChange={e => setEmail(e.target.value)} />
+                <textarea placeholder="Açıklama (En az 5 karakter)" value={desc} onChange={e => setDesc(e.target.value)} />
+                <button onClick={handleSubmit} disabled={desc.trim().length < 5 || sending}>Gönder</button>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/UploadStep.js
+++ b/frontend/src/components/UploadStep.js
@@ -4,15 +4,17 @@ import { useTranslation } from 'react-i18next';
 import Logo from './Logo';
 import LanguageSwitcher from './LanguageSwitcher';
 import ThemeSwitcher from './ThemeSwitcher';
+import Feedback from './Feedback';
 import packageJson from '../../package.json';
 
 const UploadStep = ({ onFileSelect, cvLanguage, setCvLanguage, isLoading, loadingMessage, error, theme, setTheme }) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const fileInputRef = useRef(null);
 
   return (
     <div className="upload-step fade-in">
       <div className="settings-bar">
+        <Feedback sessionId={null} language={i18n.language} theme={theme} />
         <ThemeSwitcher theme={theme} setTheme={setTheme} />
         <LanguageSwitcher />
       </div>

--- a/frontend/src/locales/tr/translation.json
+++ b/frontend/src/locales/tr/translation.json
@@ -13,7 +13,7 @@
   "skipButton": "Soruyu Atla",
   "finishButton": "CV'imi AI ile hazırla",
   "downloadCvButton": "CV’mi indir",
-  "generateCvButton": "CV’ni hazırla",
+  "generateCvButton": "CV’mi hazırla",
   "downloadCoverLetterButton": "Ön Yazıyı indir",
   "restartButton": "Yeniden başla",
   "generatingPdfButton": "PDF Sonlandırılıyor...",


### PR DESCRIPTION
## Summary
- center upload title and demo badge
- log AI question generation errors to server
- add feedback button with modal and backend storage
- adjust CV generation button text

## Testing
- `npm test -- --watchAll=false --passWithNoTests` (frontend)
- `npm test` (backend, fails: Missing script)


------
https://chatgpt.com/codex/tasks/task_e_688e5a3072a8832786b4c555169d4b0f