### PR TITLE
Refine info button and fix mobile scroll

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -117,19 +117,16 @@ body {
 .theme-switcher:hover { border-color: var(--primary-color); }
 .language-switcher button svg { width: 100%; height: 100%; display: block; object-fit: cover; }
 .feedback-icon {
-    width: 32px;
-    height: 32px;
-    border-radius: 50%;
-    border: 1px solid var(--border-color);
-    background-color: var(--surface-color);
+    width: 20px;
+    height: 20px;
     display: flex;
     align-items: center;
     justify-content: center;
     cursor: pointer;
-    color: var(--text-secondary-color);
-    transition: border-color 0.2s ease-in-out;
+    color: var(--text-primary-color);
+    font-size: 14px;
 }
-.feedback-icon:hover { border-color: var(--primary-color); }
+.feedback-icon:hover { color: var(--primary-color); }
 
 /* Feedback modal */
 .feedback-modal {
@@ -148,11 +145,12 @@ body {
     background: var(--surface-color);
     padding: 1rem;
     border-radius: 8px;
-    width: 90%;
-    max-width: 400px;
+    width: 80%;
+    max-width: 300px;
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
+    font-size: 0.9rem;
 }
 .feedback-modal input,
 .feedback-modal textarea {
@@ -339,9 +337,10 @@ input[type="file"] { display: none; }
 
 /* Mobil Uyumluluk */
 @media (max-width: 768px) {
-    .app-container { height: 100%; padding: 0; }
+    #root { min-height: 100dvh; height: 100dvh; overflow: hidden; }
+    .app-container { height: 100dvh; padding: 0; }
     .chat-step, .upload-step { height: 100dvh; width: 100vw; border-radius: 0; max-width: 100vw; box-sizing: border-box; }
     .upload-step { justify-content: center; }
     .button-group { flex-wrap: wrap; justify-content: center; }
-    .settings-bar { gap: 5px;}
+    .settings-bar { gap: 5px; }
 }

--- a/frontend/src/components/Feedback.js
+++ b/frontend/src/components/Feedback.js
@@ -39,14 +39,12 @@ export default function Feedback({ sessionId, language, theme }) {
 
   return (
     <>
-      <div className="feedback-icon" title="feedback ver" onClick={() => setOpen(true)}>
-        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
-          <path d="M8 0a8 8 0 1 0 4.906 14.32L16 16l-1.68-3.094A8 8 0 0 0 8 0zm0 1.5a6.5 6.5 0 1 1 0 13 6.5 6.5 0 0 1 0-13z"/>
-        </svg>
+      <div className="feedback-icon" title="info" onClick={() => setOpen(true)}>
+        <span>ℹ️</span>
       </div>
       {open && (
-        <div className="feedback-modal">
-          <div className="modal-content">
+        <div className="feedback-modal" onClick={() => setOpen(false)}>
+          <div className="modal-content" onClick={e => e.stopPropagation()}>
             {sent ? (
               <p>Geri bildirimin için teşekkürler!</p>
             ) : (


### PR DESCRIPTION
## Summary
- redesign info button as small monochrome ℹ icon
- shrink and close info popup when tapping outside
- adjust mobile root height to remove extra homepage scroll

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_688e5f5f32208327b56153c8ecb0f05c