### PR TITLE
Improve logging and UI details

### DIFF
--- a/backend/services/aiService.js
+++ b/backend/services/aiService.js
@@ -115,9 +115,25 @@ const getCoverLetterPrompt = (cvData, appLanguageCode) => {
 
 async function extractRawCvData(cvText, template) {
   logStep("Yapay Zeka ile Ham Veri Çıkarılıyor.");
-  const response = await openai.chat.completions.create({ model: 'gpt-4o-mini', messages: [{ role: 'user', content: getExtractionPrompt(cvText, template) }], response_format: { type: "json_object" }, });
-  logStep("Ham Veri Başarıyla Çıkarıldı.");
-  return JSON.parse(response.choices[0].message.content);
+  try {
+    const response = await openai.chat.completions.create({
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user', content: getExtractionPrompt(cvText, template) }],
+      response_format: { type: "json_object" },
+    });
+    const content = response.choices[0].message.content;
+    logStep(`Ham Veri Yanıtı: ${content}`);
+    const parsed = JSON.parse(content);
+    logStep("Ham Veri Başarıyla Çıkarıldı.");
+    return parsed;
+  } catch (error) {
+    if (error.response?.data) {
+      logStep(`Ham Veri Hatası: ${JSON.stringify(error.response.data)}`);
+    } else {
+      logStep(`Ham Veri Hatası: ${error.message}`);
+    }
+    throw error;
+  }
 }
 
 async function generateAiQuestions(cvData, appLanguage, askedQuestions = [], maxQuestions = 4) {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -80,6 +80,16 @@ body {
     font-weight: 600;
     color: var(--text-primary-color);
 }
+.logo-container .beta-tag {
+    margin-left: 8px;
+    font-size: 0.9rem;
+    color: var(--primary-color);
+    animation: betaBlink 2s ease-in-out infinite;
+}
+@keyframes betaBlink {
+    0%,100% { opacity: 1; }
+    50% { opacity: 0; }
+}
 .settings-bar {
     position: absolute;
     top: 10px;
@@ -98,6 +108,11 @@ body {
     border: 1px solid var(--border-color);
 }
 .theme-switcher { padding: 5px 8px; }
+.theme-switcher svg {
+    width: 18px;
+    height: 18px;
+    margin: 0 auto;
+}
 .language-switcher button, .theme-switcher button {
     width: 32px;
     height: 32px;
@@ -151,8 +166,16 @@ body {
     color: var(--text-primary-color);
 }
 .feedback-modal textarea { min-height: 80px; resize: vertical; }
+.feedback-modal .feedback-actions {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+.feedback-modal .feedback-version {
+    font-size: 0.8rem;
+    color: var(--text-secondary-color);
+}
 .feedback-modal button {
-    align-self: flex-end;
     background: var(--primary-color);
     color: #fff;
     border: none;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,7 +6,6 @@ import Logo from './components/Logo';
 import LanguageSwitcher from './components/LanguageSwitcher';
 import ThemeSwitcher from './components/ThemeSwitcher';
 import Feedback from './components/Feedback';
-import packageJson from '../package.json';
 import './App.css';
 
 // --- API Yapılandırması ---
@@ -316,7 +315,7 @@ function App() {
             {isLoading ? loadingMessage : t('uploadButtonLabel')}
           </label>
           {error && <p className="error-text">{error}</p>}
-          <footer>{`${t('footerText')} - v${packageJson.version}`}</footer>
+          <footer>{`${t('footerText')} - ${new Date().getFullYear()}`}</footer>
         </div>
       ) : (
         <div className="chat-step fade-in">
@@ -359,7 +358,7 @@ function App() {
             </div>
             {error && <p className="error-text">{error}</p>}
           </div>
-          <footer>{`${t('footerText')} - v${packageJson.version}`}</footer>
+          <footer>{`${t('footerText')} - ${new Date().getFullYear()}`}</footer>
         </div>
       )}
     </div>

--- a/frontend/src/components/ChatStep.js
+++ b/frontend/src/components/ChatStep.js
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next';
 import Logo from './Logo';
 import LanguageSwitcher from './LanguageSwitcher';
 import ThemeSwitcher from './ThemeSwitcher';
-import packageJson from '../../package.json';
 
 const TypingIndicator = () => <div className="message ai typing"><span></span><span></span><span></span></div>;
 const SendIcon = () => (<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"> <line x1="22" y1="2" x2="11" y2="13"></line> <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon> </svg>);
@@ -57,7 +56,7 @@ const ChatStep = ({
         </div>
         {error && <p className="error-text">{error}</p>}
       </div>
-      <footer>{`${t('footerText')} - v${packageJson.version}`}</footer>
+      <footer>{`${t('footerText')} - ${new Date().getFullYear()}`}</footer>
     </div>
   );
 };

--- a/frontend/src/components/Feedback.js
+++ b/frontend/src/components/Feedback.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import axios from 'axios';
 import { useTranslation } from 'react-i18next';
+import packageJson from '../../package.json';
 
 const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:5001';
 
@@ -51,7 +52,10 @@ export default function Feedback({ sessionId, language, theme, open, setOpen }) 
                 <input placeholder={t('feedbackNamePlaceholder')} value={name} onChange={e => setName(e.target.value)} />
                 <input placeholder={t('feedbackEmailPlaceholder')} value={email} onChange={e => setEmail(e.target.value)} />
                 <textarea placeholder={t('feedbackDescPlaceholder')} value={desc} onChange={e => setDesc(e.target.value)} />
-                <button onClick={handleSubmit} disabled={desc.trim().length < 5 || sending}>{t('feedbackSubmit')}</button>
+                <div className="feedback-actions">
+                  <span className="feedback-version">v{packageJson.version}</span>
+                  <button onClick={handleSubmit} disabled={desc.trim().length < 5 || sending}>{t('feedbackSubmit')}</button>
+                </div>
               </>
             )}
           </div>

--- a/frontend/src/components/Logo.js
+++ b/frontend/src/components/Logo.js
@@ -1,15 +1,25 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 
-const Logo = () => (
-  <div className="logo-container">
-    <svg width="42" height="42" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path d="M14 3V7C14 7.26522 14.1054 7.51957 14.2929 7.70711C14.4804 7.89464 14.7348 8 15 8H19" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-      <path d="M17 21H7C6.46957 21 5.96086 20.7893 5.58579 20.4142C5.21071 20.0391 5 19.5304 5 19V5C5 4.46957 5.21071 3.96086 5.58579 3.58579C5.96086 3.21071 6.46957 3 7 3H14L19 8V19C19 19.5304 18.7893 20.0391 18.4142 20.4142C18.0391 20.7893 17.5304 21 17 21Z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-      <path d="M12 11H9V18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-      <path d="M9 14.5C9 13.5056 9.48281 12.8716 10.3392 12.3392C11.1957 11.8067 12 11.5 12 11.5C12 11.5 12.8043 11.8067 13.6608 12.3392C14.5172 12.8716 15 13.5056 15 14.5V18H12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-    </svg>
-    <span className="logo-text">CV Builder</span>
-  </div>
-);
+const Logo = () => {
+  const [showFeedback, setShowFeedback] = useState(false);
+
+  useEffect(() => {
+    const interval = setInterval(() => setShowFeedback(prev => !prev), 4000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="logo-container">
+      <svg width="42" height="42" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M14 3V7C14 7.26522 14.1054 7.51957 14.2929 7.70711C14.4804 7.89464 14.7348 8 15 8H19" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="M17 21H7C6.46957 21 5.96086 20.7893 5.58579 20.4142C5.21071 20.0391 5 19.5304 5 19V5C5 4.46957 5.21071 3.96086 5.58579 3.58579C5.96086 3.21071 6.46957 3 7 3H14L19 8V19C19 19.5304 18.7893 20.0391 18.4142 20.4142C18.0391 20.7893 17.5304 21 17 21Z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="M12 11H9V18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="M9 14.5C9 13.5056 9.48281 12.8716 10.3392 12.3392C11.1957 11.8067 12 11.5 12 11.5C12 11.5 12.8043 11.8067 13.6608 12.3392C14.5172 12.8716 15 13.5056 15 14.5V18H12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+      <span className="logo-text">CV Builder</span>
+      <span className="beta-tag">{showFeedback ? 'any feedback?' : 'Beta'}</span>
+    </div>
+  );
+};
 
 export default Logo;

--- a/frontend/src/components/UploadStep.js
+++ b/frontend/src/components/UploadStep.js
@@ -5,7 +5,6 @@ import Logo from './Logo';
 import LanguageSwitcher from './LanguageSwitcher';
 import ThemeSwitcher from './ThemeSwitcher';
 import Feedback from './Feedback';
-import packageJson from '../../package.json';
 
 const UploadStep = ({ onFileSelect, cvLanguage, setCvLanguage, isLoading, loadingMessage, error, theme, setTheme }) => {
   const { t, i18n } = useTranslation();
@@ -44,7 +43,7 @@ const UploadStep = ({ onFileSelect, cvLanguage, setCvLanguage, isLoading, loadin
         {isLoading ? loadingMessage : t('uploadButtonLabel')} 
       </label>
       {error && <p className="error-text">{error}</p>}
-      <footer>{`${t('footerText')} - v${packageJson.version}`}</footer>
+      <footer>{`${t('footerText')} - ${new Date().getFullYear()}`}</footer>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add detailed error-handled logging for raw CV extraction
- show blinking "Beta"/"any feedback?" label in logo and version near feedback submit
- show current year in footers and center smaller theme icon

## Testing
- `npm --prefix frontend test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_688e80638b6083278c51db06acfc02c3