### PR TITLE
feat: improve feedback badge and bump version

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.2.2",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.2.2",
+      "version": "0.5.1",
       "dependencies": {
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.2.3",
+  "version": "0.5.1",
   "private": true,
   "homepage": ".",
   "dependencies": {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -80,11 +80,11 @@ body {
     font-weight: 600;
     color: var(--text-primary-color);
 }
-.logo-container .beta-tag {
+.logo-container .rotating-badge {
     margin-left: 8px;
-    font-size: 0.9rem;
-    color: var(--primary-color);
-    animation: betaBlink 2s ease-in-out infinite;
+    width: 130px;
+    text-align: center;
+    animation: betaBlink 6s ease-in-out infinite;
 }
 @keyframes betaBlink {
     0%,100% { opacity: 1; }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -305,7 +305,7 @@ function App() {
       {step === 'upload' ? (
         <div className="upload-step fade-in">
           <div className="settings-bar"><ThemeSwitcher theme={theme} setTheme={setTheme} /><LanguageSwitcher /></div>
-          <Logo />
+          <Logo onBadgeClick={() => setFeedbackOpen(true)} />
           <h1><span>{t('mainTitle')}</span><button className="demo-badge" onClick={() => setFeedbackOpen(true)}>{t('demoBadge')}</button></h1>
           <p>{t('subtitle')}</p>
           <div className="language-controls"><div className="control-group"><label htmlFor="cv-lang">{t('cvLanguageLabel')}</label><select id="cv-lang" value={cvLanguage} onChange={e => setCvLanguage(e.target.value)} disabled={isLoading}><option value="tr">Türkçe</option><option value="en">English</option></select></div></div>
@@ -319,7 +319,7 @@ function App() {
         </div>
       ) : (
         <div className="chat-step fade-in">
-          <div className="chat-header"><Logo /><div className="settings-bar"><ThemeSwitcher theme={theme} setTheme={setTheme} /><LanguageSwitcher /></div></div>
+          <div className="chat-header"><Logo onBadgeClick={() => setFeedbackOpen(true)} /><div className="settings-bar"><ThemeSwitcher theme={theme} setTheme={setTheme} /><LanguageSwitcher /></div></div>
           <div className="chat-window" ref={chatContainerRef}>{conversation.map((msg, index) => msg.type === 'typing' ? <TypingIndicator key={index} /> : <div key={index} className={`message ${msg.type}`}>{msg.text}</div>)}</div>
           <div className="chat-input-area">
             {(step === 'scriptedQuestions' || step === 'aiQuestions') && (

--- a/frontend/src/components/Logo.js
+++ b/frontend/src/components/Logo.js
@@ -1,10 +1,12 @@
 import React, { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 
-const Logo = () => {
+const Logo = ({ onBadgeClick }) => {
+  const { t } = useTranslation();
   const [showFeedback, setShowFeedback] = useState(false);
 
   useEffect(() => {
-    const interval = setInterval(() => setShowFeedback(prev => !prev), 4000);
+    const interval = setInterval(() => setShowFeedback(prev => !prev), 6000);
     return () => clearInterval(interval);
   }, []);
 
@@ -17,7 +19,13 @@ const Logo = () => {
         <path d="M9 14.5C9 13.5056 9.48281 12.8716 10.3392 12.3392C11.1957 11.8067 12 11.5 12 11.5C12 11.5 12.8043 11.8067 13.6608 12.3392C14.5172 12.8716 15 13.5056 15 14.5V18H12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
       </svg>
       <span className="logo-text">CV Builder</span>
-      <span className="beta-tag">{showFeedback ? 'any feedback?' : 'Beta'}</span>
+      <button
+        className="demo-badge rotating-badge"
+        onClick={onBadgeClick}
+        style={{ fontSize: showFeedback ? '0.45rem' : '0.8rem' }}
+      >
+        {showFeedback ? t('giveFeedback') : t('demoBadge')}
+      </button>
     </div>
   );
 };

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -20,6 +20,7 @@
   "finalMessage": "The AI's notes on your CV are ready. How shall we proceed?",
   "improveButton": "Perfect My CV",
   "demoBadge": "Beta",
+  "giveFeedback": "give feedback",
   "feedbackPrompt": "Did you encounter an error or have an idea? Your feedback is valuable.<br/>It will help us improve this app.",
   "feedbackNamePlaceholder": "Name",
   "feedbackEmailPlaceholder": "Email (Optional)",

--- a/frontend/src/locales/tr/translation.json
+++ b/frontend/src/locales/tr/translation.json
@@ -21,6 +21,7 @@
   "finalMessage": "CV’niz için yapay zekadan notlar alındı. Nasıl ilerleyelim?",
   "improveButton": "CV’mi mükemmelleştir",
   "demoBadge": "Beta",
+  "giveFeedback": "geri bildirim ver",
   "feedbackPrompt": "Hata mı aldın/ Bir fikrin mi var? Geri bildirimin çok değerli.<br/>Bu uygulamamızı geliştirmemize yardımcı olacak.",
   "feedbackNamePlaceholder": "İsim",
   "feedbackEmailPlaceholder": "Mail (Opsiyonel)",


### PR DESCRIPTION
## Summary
- replace logo Beta tag with a multilingual rotating badge that opens feedback modal
- slow badge fade animation and fix width
- bump frontend version to 0.5.1 and confirm PDF finalizing text is localized

## Testing
- `cd frontend && npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_688e846d4420832798e50f70a8e5aa65