### PR TITLE
Refine beta badge and feedback modal

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -84,11 +84,6 @@ body {
     margin-left: 8px;
     width: 130px;
     text-align: center;
-    animation: betaBlink 6s ease-in-out infinite;
-}
-@keyframes betaBlink {
-    0%,100% { opacity: 1; }
-    50% { opacity: 0; }
 }
 .settings-bar {
     position: absolute;
@@ -155,6 +150,7 @@ body {
     flex-direction: column;
     gap: 0.5rem;
     font-size: 0.9rem;
+    position: relative;
 }
 .feedback-modal input,
 .feedback-modal textarea {
@@ -186,6 +182,20 @@ body {
 .feedback-modal button:disabled {
     background: var(--secondary-color);
     cursor: not-allowed;
+}
+
+.feedback-modal .close-button {
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    background: transparent;
+    border: none;
+    font-size: 1rem;
+    cursor: pointer;
+    color: var(--text-secondary-color);
+}
+.feedback-modal .close-button:hover {
+    color: var(--text-primary-color);
 }
 footer {
     text-align: center;
@@ -335,6 +345,12 @@ input[type="file"] { display: none; }
     top: -2px;
     border: none;
     cursor: pointer;
+    opacity: 0.4;
+    transition: opacity 0.2s ease-in-out;
+}
+
+.demo-badge:hover {
+    opacity: 1;
 }
 
 .button-group button.blue {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -306,7 +306,7 @@ function App() {
         <div className="upload-step fade-in">
           <div className="settings-bar"><ThemeSwitcher theme={theme} setTheme={setTheme} /><LanguageSwitcher /></div>
           <Logo onBadgeClick={() => setFeedbackOpen(true)} />
-          <h1><span>{t('mainTitle')}</span><button className="demo-badge" onClick={() => setFeedbackOpen(true)}>{t('demoBadge')}</button></h1>
+          <h1><span>{t('mainTitle')}</span></h1>
           <p>{t('subtitle')}</p>
           <div className="language-controls"><div className="control-group"><label htmlFor="cv-lang">{t('cvLanguageLabel')}</label><select id="cv-lang" value={cvLanguage} onChange={e => setCvLanguage(e.target.value)} disabled={isLoading}><option value="tr">Türkçe</option><option value="en">English</option></select></div></div>
           <input type="file" id="file-upload" ref={fileInputRef} onChange={handleInitialParse} disabled={isLoading} accept=".pdf,.docx" style={{ display: 'none' }} />

--- a/frontend/src/components/Feedback.js
+++ b/frontend/src/components/Feedback.js
@@ -44,6 +44,7 @@ export default function Feedback({ sessionId, language, theme, open, setOpen }) 
       {open && (
         <div className="feedback-modal" onClick={() => setOpen(false)}>
           <div className="modal-content" onClick={e => e.stopPropagation()}>
+            <button className="close-button" onClick={() => setOpen(false)}>×</button>
             {sent ? (
               <p>{t('feedbackThanks')}</p>
             ) : (

--- a/frontend/src/components/Logo.js
+++ b/frontend/src/components/Logo.js
@@ -1,14 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 const Logo = ({ onBadgeClick }) => {
   const { t } = useTranslation();
-  const [showFeedback, setShowFeedback] = useState(false);
-
-  useEffect(() => {
-    const interval = setInterval(() => setShowFeedback(prev => !prev), 6000);
-    return () => clearInterval(interval);
-  }, []);
+  const [hovered, setHovered] = useState(false);
 
   return (
     <div className="logo-container">
@@ -22,9 +17,11 @@ const Logo = ({ onBadgeClick }) => {
       <button
         className="demo-badge rotating-badge"
         onClick={onBadgeClick}
-        style={{ fontSize: showFeedback ? '0.45rem' : '0.8rem' }}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+        style={{ fontSize: hovered ? '0.45rem' : '0.8rem' }}
       >
-        {showFeedback ? t('giveFeedback') : t('demoBadge')}
+        {hovered ? t('giveFeedback') : t('demoBadge')}
       </button>
     </div>
   );


### PR DESCRIPTION
## Summary
- Remove extra Beta button from upload screen and reduce badge visibility
- Show feedback prompt when hovering Beta badge
- Add dismissible close button to feedback modal

## Testing
- `cd frontend && npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_688e8b1c5c8083279863a418d6951556