### PR TITLE
Refine beta badge and theme switcher

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -82,13 +82,8 @@ body {
 }
 .logo-container .rotating-badge {
     margin-left: 8px;
-    width: 130px;
+    width: auto;
     text-align: center;
-    animation: betaBlink 6s ease-in-out infinite;
-}
-@keyframes betaBlink {
-    0%,100% { opacity: 1; }
-    50% { opacity: 0; }
 }
 .settings-bar {
     position: absolute;
@@ -106,12 +101,13 @@ body {
     border-radius: 20px;
     box-shadow: 0 2px 5px rgba(0,0,0,0.1);
     border: 1px solid var(--border-color);
+    align-items: center;
+    justify-content: center;
 }
 .theme-switcher { padding: 5px 8px; }
 .theme-switcher svg {
     width: 18px;
     height: 18px;
-    margin: 0 auto;
 }
 .language-switcher button, .theme-switcher button {
     width: 32px;
@@ -155,6 +151,7 @@ body {
     flex-direction: column;
     gap: 0.5rem;
     font-size: 0.9rem;
+    position: relative;
 }
 .feedback-modal input,
 .feedback-modal textarea {
@@ -186,6 +183,20 @@ body {
 .feedback-modal button:disabled {
     background: var(--secondary-color);
     cursor: not-allowed;
+}
+
+.feedback-modal .close-button {
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    background: transparent;
+    border: none;
+    font-size: 1rem;
+    cursor: pointer;
+    color: var(--text-secondary-color);
+}
+.feedback-modal .close-button:hover {
+    color: var(--text-primary-color);
 }
 footer {
     text-align: center;
@@ -335,6 +346,36 @@ input[type="file"] { display: none; }
     top: -2px;
     border: none;
     cursor: pointer;
+    opacity: 0.6;
+    transition: opacity 0.2s ease-in-out;
+    font-weight: 700;
+}
+
+.demo-badge:hover {
+    opacity: 1;
+}
+
+.demo-badge .badge-tooltip {
+    visibility: hidden;
+    opacity: 0;
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    top: 100%;
+    background-color: var(--text-primary-color);
+    color: var(--background-color);
+    padding: 2px 6px;
+    border-radius: 4px;
+    white-space: nowrap;
+    font-size: 0.55rem;
+    margin-top: 4px;
+    transition: opacity 0.2s ease-in-out;
+    z-index: 100;
+}
+
+.demo-badge:hover .badge-tooltip {
+    visibility: visible;
+    opacity: 1;
 }
 
 .button-group button.blue {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -306,7 +306,7 @@ function App() {
         <div className="upload-step fade-in">
           <div className="settings-bar"><ThemeSwitcher theme={theme} setTheme={setTheme} /><LanguageSwitcher /></div>
           <Logo onBadgeClick={() => setFeedbackOpen(true)} />
-          <h1><span>{t('mainTitle')}</span><button className="demo-badge" onClick={() => setFeedbackOpen(true)}>{t('demoBadge')}</button></h1>
+          <h1><span>{t('mainTitle')}</span></h1>
           <p>{t('subtitle')}</p>
           <div className="language-controls"><div className="control-group"><label htmlFor="cv-lang">{t('cvLanguageLabel')}</label><select id="cv-lang" value={cvLanguage} onChange={e => setCvLanguage(e.target.value)} disabled={isLoading}><option value="tr">Türkçe</option><option value="en">English</option></select></div></div>
           <input type="file" id="file-upload" ref={fileInputRef} onChange={handleInitialParse} disabled={isLoading} accept=".pdf,.docx" style={{ display: 'none' }} />

--- a/frontend/src/components/Feedback.js
+++ b/frontend/src/components/Feedback.js
@@ -44,6 +44,7 @@ export default function Feedback({ sessionId, language, theme, open, setOpen }) 
       {open && (
         <div className="feedback-modal" onClick={() => setOpen(false)}>
           <div className="modal-content" onClick={e => e.stopPropagation()}>
+            <button className="close-button" onClick={() => setOpen(false)}>×</button>
             {sent ? (
               <p>{t('feedbackThanks')}</p>
             ) : (

--- a/frontend/src/components/Logo.js
+++ b/frontend/src/components/Logo.js
@@ -1,14 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 const Logo = ({ onBadgeClick }) => {
   const { t } = useTranslation();
-  const [showFeedback, setShowFeedback] = useState(false);
-
-  useEffect(() => {
-    const interval = setInterval(() => setShowFeedback(prev => !prev), 6000);
-    return () => clearInterval(interval);
-  }, []);
 
   return (
     <div className="logo-container">
@@ -19,12 +13,9 @@ const Logo = ({ onBadgeClick }) => {
         <path d="M9 14.5C9 13.5056 9.48281 12.8716 10.3392 12.3392C11.1957 11.8067 12 11.5 12 11.5C12 11.5 12.8043 11.8067 13.6608 12.3392C14.5172 12.8716 15 13.5056 15 14.5V18H12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
       </svg>
       <span className="logo-text">CV Builder</span>
-      <button
-        className="demo-badge rotating-badge"
-        onClick={onBadgeClick}
-        style={{ fontSize: showFeedback ? '0.45rem' : '0.8rem' }}
-      >
-        {showFeedback ? t('giveFeedback') : t('demoBadge')}
+      <button className="demo-badge rotating-badge" onClick={onBadgeClick}>
+        {t('demoBadge')} ℹ️
+        <span className="badge-tooltip">{t('giveFeedback')}</span>
       </button>
     </div>
   );

--- a/frontend/src/components/ThemeSwitcher.js
+++ b/frontend/src/components/ThemeSwitcher.js
@@ -9,9 +9,11 @@ const ThemeSwitcher = ({ theme, setTheme }) => {
   };
 
   return (
-    <button onClick={toggleTheme} className="theme-switcher" aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}>
-      {theme === 'light' ? <MoonIcon /> : <SunIcon />}
-    </button>
+    <div className="theme-switcher">
+      <button onClick={toggleTheme} aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}>
+        {theme === 'light' ? <MoonIcon /> : <SunIcon />}
+      </button>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- Display bold "Beta ℹ️" badge with hover tooltip for feedback and slightly higher default opacity
- Center the light/dark mode icons within the theme toggle

## Testing
- `cd frontend && npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_688e8b1c5c8083279863a418d6951556