### PR TITLE
Remove beta badge fade and widen language select

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -243,6 +243,7 @@ footer {
     color: var(--text-primary-color);
     box-shadow: 0 2px 6px rgba(0,0,0,0.05);
     cursor: pointer;
+    min-width: 120px;
     appearance: none;
     background-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'><path fill='%23333' d='M6 8L0 0h12z'/></svg>");
     background-repeat: no-repeat;
@@ -346,7 +347,7 @@ input[type="file"] { display: none; }
     top: -2px;
     border: none;
     cursor: pointer;
-    opacity: 0.6;
+    opacity: 1;
     transition: opacity 0.2s ease-in-out;
     font-weight: 700;
 }


### PR DESCRIPTION
## Summary
- make beta badge fully opaque
- slightly increase minimum width of target CV language select

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688f08a390948327868de95755863d43