### PR TITLE
style: update beta badge info icon

### DIFF
--- a/frontend/src/components/Logo.js
+++ b/frontend/src/components/Logo.js
@@ -14,7 +14,7 @@ const Logo = ({ onBadgeClick }) => {
       </svg>
       <span className="logo-text">CV Builder</span>
       <button className="demo-badge rotating-badge" onClick={onBadgeClick}>
-        {t('demoBadge')} ℹ️
+        {t('demoBadge')} |ℹ︎
         <span className="badge-tooltip">{t('giveFeedback')}</span>
       </button>
     </div>


### PR DESCRIPTION
## Summary
- add a vertical bar before info icon in demo badge

## Testing
- `cd frontend && npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688f0a973c00832785440768e0985caf