### PR TITLE
Improve question clarity and first-person CV integration

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "CV Builder backend",
   "main": "server.js",
   "scripts": {

--- a/backend/services/aiService.js
+++ b/backend/services/aiService.js
@@ -46,6 +46,8 @@ const getAiQuestionsPrompt = (cvData, appLanguageCode, askedQuestions = [], maxQ
   4. **ORDER:** Start with the most important missing section and proceed in descending importance.
   5. **LIMIT:** Maximum ${maxQuestions} short questions.
   6. **TONE:** Phrase each item as an observation followed by a polite request, using the correct section name.
+  7. **SPECIFICITY:** Mention the exact item missing information (e.g., project name) so the user knows what to provide.
+  8. **QUALITY CHECK:** If a section exists but looks weak, tell the user it doesn't look good and suggest how to improve it, then ask for a better version.
 
   Your final output MUST be a single JSON object with the key "questions", containing an array of strings written in ${appLanguage}.
 
@@ -65,8 +67,10 @@ const getFinalizeCvPrompt = (cvData, targetLanguageCode) => {
   You are a master CV writer. Take the following structured CV JSON data, which includes user's answers to your questions, and transform it into a perfectly polished, professional CV.
   - **LANGUAGE RULE**: The final output's every single string value (summaries, descriptions, titles, categories, etc.) **MUST BE IN ${targetLanguage}**. No exceptions or other languages are permitted.
   - **ACTION**: Rewrite all job descriptions to start with strong action verbs. Integrate quantifiable achievements provided by the user. Polish the language to be professional and concise.
-  - **SUMMARY**: Create a powerful new summary that encapsulates the candidate's strongest skills and most impressive experiences from the entire dataset.
+  - **SUMMARY**: Create a powerful new summary that encapsulates the candidate's strongest skills and most impressive experiences from the entire dataset, written from a first-person perspective.
+  - **FIRST PERSON:** Ensure all narrative text, including summaries and descriptions, reads as if written by the candidate using "I" statements where appropriate.
   - **INTEGRATION**: If a 'userAdditions' array exists, interpret each {question, answer} pair and integrate the answers into the most relevant fields so no user-provided detail is lost.
+  - **REFERENCES**: Include any provided reference information in a dedicated references section.
   - **CLEANUP**: Ensure consistent formatting throughout. Remove any notes or irrelevant information (like a 'userAdditions' field).
   - Return only the final, polished JSON object. The structure should remain the same as the input.
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "homepage": ".",
   "dependencies": {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -339,7 +339,7 @@ input[type="file"] { display: none; }
 .demo-badge {
     background-color: var(--primary-color);
     color: #fff;
-    font-size: 0.55rem;
+    font-size: 0.65rem;
     padding: 1px 4px;
     border-radius: 4px;
     vertical-align: middle;

--- a/sample_cv_template.json
+++ b/sample_cv_template.json
@@ -37,6 +37,13 @@
       "proficiency": "Native"
     }
   ],
+  "references": [
+    {
+      "name": "Jane Smith",
+      "contact": "jane.smith@example.com",
+      "relationship": "Former Manager"
+    }
+  ],
   "projects": [
     {
       "name": "Project X",


### PR DESCRIPTION
## Summary
- ensure references answers are retained by adding a references section and merging user-provided data
- clarify AI follow-up questions and enforce first-person, reference-aware final CV generation
- enlarge Beta info badge text for better visibility and bump package versions

## Testing
- `CI=true npm test --silent` (frontend)
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_688f0e41a6fc8327a644443066681707