### PR TITLE
feat: enlarge desktop fonts and update skills format

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "1.3.4",
+  "version": "0.3.10",
   "description": "CV Builder backend",
   "main": "server.js",
   "scripts": {

--- a/backend/services/pdfService.js
+++ b/backend/services/pdfService.js
@@ -33,6 +33,22 @@ const headingMap = {
     tr: { summary: 'Özet', experience: 'Deneyim', education: 'Eğitim', skills: 'Yetenekler', projects: 'Projeler', languages: 'Diller', certificates: 'Sertifikalar', analysis: 'AI Analizi' }
 };
 
+const renderSkills = (skills = []) => {
+    const grouped = skills.reduce((acc, skill) => {
+        const category = skill.category || '';
+        if (!acc[category]) acc[category] = [];
+        acc[category].push(skill);
+        return acc;
+    }, {});
+    return `<div class="skills-container">` +
+        Object.entries(grouped).map(([category, list]) => `
+            <div class="skills-category">
+                ${category ? `<h4>${category}</h4>` : ''}
+                <ul>${list.map(s => `<li>${s.name}${s.level ? ` - ${s.level}` : ''}</li>`).join('')}</ul>
+            </div>`).join('') +
+        `</div>`;
+};
+
 const generateCvHtml = (data, language = 'en') => {
     const t = headingMap[language] || headingMap.en;
     const fullName = (data.personalInfo?.name || `${data.personalInfo?.firstName || ''} ${data.personalInfo?.lastName || ''}`.trim()).trim();
@@ -71,7 +87,7 @@ const generateCvHtml = (data, language = 'en') => {
         ${data.summary ? `<div class="section"><h2 class="section-title">${t.summary}</h2><p>${data.summary}</p></div>` : ''}
         ${data.experience && data.experience.length > 0 ? `<div class="section"><h2 class="section-title">${t.experience}</h2>${data.experience.map(exp => `<div class="item-container"><div class="item-content"><h3>${exp.title || ''}</h3><div class="sub-header">${exp.company || ''} | ${exp.location || ''}</div><ul>${(exp.description || '').split('\\n').filter(d => d.trim() !== '').map(d => `<li>${d.replace(/^- /, '')}</li>`).join('')}</ul></div><div class="item-date">${exp.date || ''}</div></div>`).join('')}</div>` : ''}
         ${data.education && data.education.length > 0 ? `<div class="section"><h2 class="section-title">${t.education}</h2>${data.education.map(edu => `<div class="item-container"><div class="item-content"><h3>${edu.degree || ''}</h3><p>${edu.institution || ''}</p></div><div class="item-date">${edu.date || ''}</div></div>`).join('')}</div>` : ''}
-        ${data.skillsByCategory && data.skillsByCategory.length > 0 ? `<div class="section"><h2 class="section-title">${t.skills}</h2><div class="skills-container">${data.skillsByCategory.map(cat => `<div class="skills-category"><h4>${cat.category || ''}</h4><ul>${(cat.skills || []).map(s => `<li>${s}</li>`).join('')}</ul></div>`).join('')}</div></div>` : ''}
+        ${data.skills && data.skills.length > 0 ? `<div class="section"><h2 class="section-title">${t.skills}</h2>${renderSkills(data.skills)}</div>` : ''}
         ${data.projects && data.projects.length > 0 ? `<div class="section projects"><h2 class="section-title">${t.projects}</h2>${data.projects.map(proj => `<div><h3>${proj.name || ''}</h3><p>${proj.description || ''}</p>${proj.url ? `<p><a href="${proj.url}">${proj.url}</a></p>` : ''}</div>`).join('')}</div>` : ''}
         ${data.languages && data.languages.length > 0 ? `<div class="section"><h2 class="section-title">${t.languages}</h2>${data.languages.map(lang => `<p>${(lang.language || '')} ${lang.proficiency ? '(' + lang.proficiency + ')' : ''}</p>`).join('')}</div>` : ''}
         ${data.certificates && data.certificates.length > 0 ? `<div class="section"><h2 class="section-title">${t.certificates}</h2>${data.certificates.map(cert => {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.5.2",
+  "version": "0.3.20",
   "private": true,
   "homepage": ".",
   "dependencies": {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -45,6 +45,12 @@ body {
     transition: background-color 0.3s ease, color 0.3s ease;
 }
 
+@media (min-width: 769px) {
+    body {
+        font-size: 17px;
+    }
+}
+
 #root {
     display: flex;
     justify-content: center;
@@ -349,7 +355,7 @@ input[type="file"] { display: none; }
     cursor: pointer;
     opacity: 1;
     transition: opacity 0.2s ease-in-out;
-    font-weight: 700;
+    font-weight: 400;
 }
 
 .demo-badge:hover {
@@ -377,6 +383,11 @@ input[type="file"] { display: none; }
 .demo-badge:hover .badge-tooltip {
     visibility: visible;
     opacity: 1;
+}
+
+.demo-badge .info-icon {
+    font-family: 'Playfair Display', serif;
+    font-weight: 400;
 }
 
 .button-group button.blue {

--- a/frontend/src/components/Logo.js
+++ b/frontend/src/components/Logo.js
@@ -14,7 +14,8 @@ const Logo = ({ onBadgeClick }) => {
       </svg>
       <span className="logo-text">CV Builder</span>
       <button className="demo-badge rotating-badge" onClick={onBadgeClick}>
-        {t('demoBadge')} |ℹ︎
+        <span className="beta-text">{t('demoBadge')}</span> |
+        <span className="info-icon">ℹ︎</span>
         <span className="badge-tooltip">{t('giveFeedback')}</span>
       </button>
     </div>

--- a/sample_cv_template.json
+++ b/sample_cv_template.json
@@ -25,10 +25,11 @@
   "certificates": [
     "AWS Certified Solutions Architect"
   ],
-  "skillsByCategory": [
+  "skills": [
     {
+      "name": "JavaScript",
       "category": "Programming",
-      "skills": ["JavaScript", "Python", "Java"]
+      "level": "Advanced"
     }
   ],
   "languages": [


### PR DESCRIPTION
## Summary
- enlarge desktop fonts for better readability
- allow skills without category and optional levels, update PDF rendering
- tweak beta badge styling

## Testing
- `CI=true npm test --prefix frontend -- --watchAll=false --passWithNoTests`
- `npm test --prefix backend` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f1941b398832799ed04801f79c0cd