### PR TITLE
feat: prompt for location and phone

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -57,6 +57,8 @@ function App() {
     const hasName = get(data, 'personalInfo.name') || get(data, 'personalInfo.firstName');
     if (!hasName) { queue.push({ key: 'askName', path: 'personalInfo.name' }); }
     if (!get(data, 'personalInfo.email')) { queue.push({ key: 'askEmail', path: 'personalInfo.email' }); }
+    if (!get(data, 'personalInfo.location')) { queue.push({ key: 'askLocation', path: 'personalInfo.location' }); }
+    if (!get(data, 'personalInfo.phone')) { queue.push({ key: 'askPhone', path: 'personalInfo.phone' }); }
 
     setCvData(data);
     setQuestionQueue(queue);

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -8,6 +8,7 @@
   "askName": "Great! A name was not found in your CV. Please provide your full name.",
   "askEmail": "Got it. Let's add a contact email address.",
   "askPhone": "Perfect. Would you like to add your phone number as well?",
+  "askLocation": "Great. Could you share your location?",
   "chatPlaceholder": "Type your answer here...",
   "answerButton": "Send",
   "skipButton": "Skip Question",

--- a/frontend/src/locales/tr/translation.json
+++ b/frontend/src/locales/tr/translation.json
@@ -8,6 +8,7 @@
   "askName": "Harika! CV'nizde bir isim bulunamadı. Lütfen tam adınızı yazar mısınız?",
   "askEmail": "Anlaşıldı. İletişim için bir e-posta adresi ekleyelim mi?",
   "askPhone": "Çok iyi. Telefon numaranızı da eklemek ister misiniz?",
+  "askLocation": "Anlaşıldı. Bulunduğunuz konumu da paylaşır mısınız?",
   "chatPlaceholder": "Cevabınızı buraya yazın...",
   "answerButton": "Gönder",
   "skipButton": "Soruyu Atla",


### PR DESCRIPTION
## Summary
- Queue phone and location questions when missing
- Add English and Turkish translations for location prompt

## Testing
- `CI=true npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_688f26eb99e48327b452b414a280c36f