### PR TITLE
Clear loading message after CV parsing

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -84,6 +84,7 @@ function App() {
       startScriptedQuestions(res.data.parsedData);
     } catch (err) {
       setError(err.response?.data?.message || t('errorOccurred'));
+    } finally {
       setLoadingMessage('');
     }
   };


### PR DESCRIPTION
## Summary
- Reset loading indicator after parsing CV with a finally block

## Testing
- `CI=true npm test --silent -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_688f3e665ad083279ff6bdad1a0c1b88