### PR TITLE
Refine Tailwind styling and add skeleton loader

### DIFF
--- a/frontend/src/components/CVBuilder.js
+++ b/frontend/src/components/CVBuilder.js
@@ -4,6 +4,7 @@ import { useCVForm } from '../hooks/useCVForm';
 import MainLayout from './layout/MainLayout';
 import CVPreview from './CVPreview';
 import CVForm from './CVForm';
+import { Skeleton } from './ui/skeleton';
 
 const PDFExportButton = lazy(() => import('./PDFExportButton'));
 
@@ -18,7 +19,7 @@ export default function CVBuilder() {
         <>
           <CVPreview data={data} />
           <div className="mt-4">
-            <Suspense fallback={<div>{t('generatingPdfButton')}</div>}>
+            <Suspense fallback={<Skeleton className="h-12 w-full" />}>
               <PDFExportButton data={data} t={t} />
             </Suspense>
           </div>

--- a/frontend/src/components/CVForm.js
+++ b/frontend/src/components/CVForm.js
@@ -4,6 +4,7 @@ import PersonalSection from './sections/PersonalSection';
 import ExperienceSection from './sections/ExperienceSection';
 import EducationSection from './sections/EducationSection';
 import SkillsSection from './sections/SkillsSection';
+import { Button } from './ui/button';
 
 function CVForm({ step, data, addItem, updateItem, duplicateItem, onDragEnd, next, prev, resetAll, personalForm, stepKeys }) {
   const { t } = useTranslation();
@@ -52,17 +53,13 @@ function CVForm({ step, data, addItem, updateItem, duplicateItem, onDragEnd, nex
 
   return (
     <div className="space-y-4">
-      <div className="flex justify-between items-center">
-        <div className="w-full bg-gray-200 h-2 rounded mr-4">
+      <div className="flex items-center gap-4">
+        <div className="w-full bg-gray-200 h-2 rounded">
           <div className="bg-blue-500 h-2 rounded" style={{ width: `${progress}%` }} />
         </div>
-        <button
-          type="button"
-          onClick={resetAll}
-          className="px-2 py-1 bg-red-500 text-white rounded text-sm"
-        >
+        <Button size="sm" variant="outline" onClick={resetAll}>
           {t('resetAll')}
-        </button>
+        </Button>
       </div>
       <h2 className="text-xl font-semibold">
         {t('step', { number: step + 1, name: steps[step] })}
@@ -70,14 +67,14 @@ function CVForm({ step, data, addItem, updateItem, duplicateItem, onDragEnd, nex
       {renderStep()}
       <div className="flex justify-between">
         {step > 0 && (
-          <button type="button" onClick={prev} className="px-4 py-2 bg-gray-200 rounded">
+          <Button type="button" onClick={prev} variant="outline">
             {t('back')}
-          </button>
+          </Button>
         )}
         {step < steps.length - 1 && (
-          <button type="button" onClick={next} className="ml-auto px-4 py-2 bg-blue-500 text-white rounded">
+          <Button type="button" onClick={next} className="ml-auto">
             {t('next')}
-          </button>
+          </Button>
         )}
       </div>
     </div>

--- a/frontend/src/components/Feedback.js
+++ b/frontend/src/components/Feedback.js
@@ -58,7 +58,12 @@ export default function Feedback({ sessionId, language, theme, open, setOpen }) 
               <p className="mb-4" dangerouslySetInnerHTML={{ __html: t('feedbackPrompt') }} />
               <Input className="mb-2" placeholder={t('feedbackNamePlaceholder')} value={name} onChange={e => setName(e.target.value)} />
               <Input className="mb-2" placeholder={t('feedbackEmailPlaceholder')} value={email} onChange={e => setEmail(e.target.value)} />
-              <textarea className="w-full border rounded-md p-2 mb-4" placeholder={t('feedbackDescPlaceholder')} value={desc} onChange={e => setDesc(e.target.value)} />
+              <textarea
+                className="w-full rounded-lg border border-gray-300 bg-white dark:bg-zinc-900 p-4 mb-4 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2"
+                placeholder={t('feedbackDescPlaceholder')}
+                value={desc}
+                onChange={e => setDesc(e.target.value)}
+              />
               <DialogFooter>
                 <span className="text-sm text-gray-500">v{packageJson.version}</span>
                 <Button onClick={handleSubmit} disabled={desc.trim().length < 5 || sending}>{t('feedbackSubmit')}</Button>

--- a/frontend/src/components/sections/ListSection.js
+++ b/frontend/src/components/sections/ListSection.js
@@ -1,20 +1,18 @@
 import React from 'react';
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
+import { Input } from '../ui/input';
+import { Button } from '../ui/button';
 
 export default function ListSection({ field, items, keys, addItem, updateItem, duplicateItem, onDragEnd, t }) {
   return (
     <div>
-      <button
-        type="button"
-        onClick={() => addItem(field)}
-        className="mb-2 px-2 py-1 bg-blue-500 text-white rounded"
-      >
+      <Button type="button" onClick={() => addItem(field)} className="mb-4">
         {t('add')}
-      </button>
+      </Button>
       <DragDropContext onDragEnd={onDragEnd(field)}>
         <Droppable droppableId={field}>
           {provided => (
-            <div ref={provided.innerRef} {...provided.droppableProps} className="space-y-2">
+            <div ref={provided.innerRef} {...provided.droppableProps} className="space-y-4">
               {items.map((item, index) => (
                 <Draggable key={index} draggableId={`${field}-${index}`} index={index}>
                   {provided => (
@@ -22,25 +20,25 @@ export default function ListSection({ field, items, keys, addItem, updateItem, d
                       ref={provided.innerRef}
                       {...provided.draggableProps}
                       {...provided.dragHandleProps}
-                      className="p-2 border rounded"
+                      className="space-y-2 rounded-lg bg-white dark:bg-zinc-900 p-4 shadow-sm"
                     >
                       {keys.map(k => (
-                        <input
+                        <Input
                           key={k}
                           name={k}
                           placeholder={t(k)}
                           value={item[k] || ''}
                           onChange={e => updateItem(field, index, k, e.target.value)}
-                          className="block w-full mb-1 p-1 border rounded"
+                          className="mb-2"
                         />
                       ))}
-                      <button
+                      <Button
                         type="button"
+                        variant="outline"
                         onClick={() => duplicateItem(field, index)}
-                        className="mt-1 px-2 py-1 bg-gray-200 rounded"
                       >
                         {t('duplicate')}
-                      </button>
+                      </Button>
                     </div>
                   )}
                 </Draggable>

--- a/frontend/src/components/sections/PersonalSection.js
+++ b/frontend/src/components/sections/PersonalSection.js
@@ -1,36 +1,21 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { Input } from '../ui/input';
 
 export default function PersonalSection({ form }) {
   const { t } = useTranslation();
   return (
-    <div className="space-y-2">
-      <input
-        {...form.register('name')}
-        placeholder={t('name')}
-        className="w-full p-2 border rounded"
-      />
+    <div className="space-y-4">
+      <Input {...form.register('name')} placeholder={t('name')} />
       {form.formState.errors.name && (
         <p className="text-red-500 text-sm">{form.formState.errors.name.message}</p>
       )}
-      <input
-        {...form.register('email')}
-        placeholder={t('email')}
-        className="w-full p-2 border rounded"
-      />
+      <Input {...form.register('email')} placeholder={t('email')} />
       {form.formState.errors.email && (
         <p className="text-red-500 text-sm">{form.formState.errors.email.message}</p>
       )}
-      <input
-        {...form.register('phone')}
-        placeholder={t('phone')}
-        className="w-full p-2 border rounded"
-      />
-      <input
-        {...form.register('location')}
-        placeholder={t('location')}
-        className="w-full p-2 border rounded"
-      />
+      <Input {...form.register('phone')} placeholder={t('phone')} />
+      <Input {...form.register('location')} placeholder={t('location')} />
     </div>
   );
 }

--- a/frontend/src/components/ui/button.js
+++ b/frontend/src/components/ui/button.js
@@ -1,11 +1,10 @@
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
-import { motion } from "framer-motion";
 import { cva } from "class-variance-authority";
 import { cn } from "../../lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none disabled:opacity-50 disabled:pointer-events-none",
+  "inline-flex items-center justify-center rounded-lg font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 disabled:opacity-50 disabled:pointer-events-none shadow",
   {
     variants: {
       variant: {
@@ -14,9 +13,9 @@ const buttonVariants = cva(
         ghost: "hover:bg-gray-100",
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 px-3",
-        lg: "h-11 px-8",
+        default: "px-5 py-3 text-lg",
+        sm: "px-3 py-2 text-sm",
+        lg: "px-6 py-4 text-xl",
         icon: "h-10 w-10",
       },
     },
@@ -29,20 +28,10 @@ const buttonVariants = cva(
 
 const Button = React.forwardRef(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
-    if (asChild) {
-      return (
-        <Slot
-          ref={ref}
-          className={cn(buttonVariants({ variant, size, className }))}
-          {...props}
-        />
-      );
-    }
+    const Comp = asChild ? Slot : "button";
     return (
-      <motion.button
+      <Comp
         ref={ref}
-        whileHover={{ scale: 1.05 }}
-        whileTap={{ scale: 0.95 }}
         className={cn(buttonVariants({ variant, size, className }))}
         {...props}
       />

--- a/frontend/src/components/ui/card.js
+++ b/frontend/src/components/ui/card.js
@@ -9,7 +9,7 @@ const Card = React.forwardRef(({ className, ...props }, ref) => (
     animate={{ opacity: 1, y: 0 }}
     transition={{ duration: 0.3 }}
     className={cn(
-      "rounded-xl border bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 shadow",
+      "rounded-lg bg-white dark:bg-zinc-900 text-gray-900 dark:text-gray-100 shadow-sm",
       className
     )}
     {...props}
@@ -18,7 +18,7 @@ const Card = React.forwardRef(({ className, ...props }, ref) => (
 Card.displayName = "Card";
 
 const CardHeader = React.forwardRef(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("flex flex-col space-y-1.5 p-6", className)} {...props} />
+  <div ref={ref} className={cn("flex flex-col gap-4 p-4", className)} {...props} />
 ));
 CardHeader.displayName = "CardHeader";
 
@@ -28,7 +28,7 @@ const CardTitle = React.forwardRef(({ className, ...props }, ref) => (
 CardTitle.displayName = "CardTitle";
 
 const CardContent = React.forwardRef(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  <div ref={ref} className={cn("p-4 pt-0", className)} {...props} />
 ));
 CardContent.displayName = "CardContent";
 

--- a/frontend/src/components/ui/dialog.js
+++ b/frontend/src/components/ui/dialog.js
@@ -35,7 +35,7 @@ const DialogContent = React.forwardRef(({ className, children, ...props }, ref) 
         exit={{ opacity: 0, scale: 0.95 }}
         transition={{ duration: 0.2 }}
       >
-        <div className="relative w-full max-w-md rounded-2xl bg-white dark:bg-gray-800 p-6 shadow-md">
+        <div className="relative w-full max-w-md rounded-lg bg-white dark:bg-zinc-900 p-4 shadow-sm">
           {children}
         </div>
       </motion.div>
@@ -45,11 +45,11 @@ const DialogContent = React.forwardRef(({ className, children, ...props }, ref) 
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 const DialogHeader = ({ className, ...props }) => (
-  <div className={cn("flex flex-col space-y-1.5", className)} {...props} />
+  <div className={cn("flex flex-col gap-4", className)} {...props} />
 );
 
 const DialogFooter = ({ className, ...props }) => (
-  <div className={cn("flex items-center justify-between", className)} {...props} />
+  <div className={cn("flex items-center justify-between gap-4", className)} {...props} />
 );
 
 const DialogTitle = React.forwardRef(({ className, ...props }, ref) => (

--- a/frontend/src/components/ui/dropdown-menu.js
+++ b/frontend/src/components/ui/dropdown-menu.js
@@ -8,7 +8,7 @@ const DropdownMenuContent = React.forwardRef(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.Content
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-white dark:bg-gray-800 p-1 text-gray-700 shadow-md",
+      "z-50 min-w-[8rem] overflow-hidden rounded-lg bg-white dark:bg-zinc-900 p-1 text-gray-700 shadow-sm",
       className
     )}
     {...props}
@@ -20,7 +20,7 @@ const DropdownMenuItem = React.forwardRef(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-gray-100 dark:focus:bg-gray-700",
+      "flex cursor-pointer select-none items-center rounded-md px-4 py-2 text-sm outline-none focus:bg-gray-100 dark:focus:bg-zinc-700",
       className
     )}
     {...props}

--- a/frontend/src/components/ui/input.js
+++ b/frontend/src/components/ui/input.js
@@ -4,7 +4,10 @@ import { cn } from "../../lib/utils";
 const Input = React.forwardRef(({ className, type = "text", ...props }, ref) => (
   <input
     type={type}
-    className={cn("flex h-10 w-full rounded-md border border-gray-300 bg-transparent px-3 py-2 text-sm placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 disabled:cursor-not-allowed disabled:opacity-50", className)}
+    className={cn(
+      "flex h-10 w-full rounded-lg border border-gray-300 bg-white dark:bg-zinc-900 px-4 py-2 text-sm shadow-sm placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 transition",
+      className
+    )}
     ref={ref}
     {...props}
   />

--- a/frontend/src/components/ui/skeleton.js
+++ b/frontend/src/components/ui/skeleton.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { cn } from '../../lib/utils';
+
+function Skeleton({ className, ...props }) {
+  return (
+    <div
+      className={cn('animate-pulse rounded-md bg-gray-200 dark:bg-zinc-700', className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,9 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  @apply bg-gray-50 dark:bg-zinc-950 text-gray-900 dark:text-gray-100 font-sans;
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -3,7 +3,11 @@ module.exports = {
   darkMode: 'class',
   content: ["./src/**/*.{js,jsx,ts,tsx,html}"],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ["Inter", "ui-sans-serif", "system-ui", "sans-serif"],
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- adopt Inter as default font and unify theme spacing/colors
- refine UI elements (card, button, input, dialog, dropdown) with consistent Tailwind styling and shadows
- add reusable skeleton loader and use it for async PDF export
- align form sections with updated components for consistent spacing

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_689643e1ca5c83278469c177b0575c30