### PR TITLE
feat: show toast when cv is ready

### DIFF
--- a/frontend/src/components/PDFExportButton.js
+++ b/frontend/src/components/PDFExportButton.js
@@ -1,15 +1,33 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { PDFDownloadLink } from '@react-pdf/renderer';
 import CVDocument from './CVDocument';
+import Toast from './ui/toast';
 
 export default function PDFExportButton({ data, t }) {
+  const [loadingState, setLoadingState] = useState(true);
+  const [showToast, setShowToast] = useState(false);
+
+  useEffect(() => {
+    if (!loadingState) {
+      setShowToast(true);
+    }
+  }, [loadingState]);
+
   return (
-    <PDFDownloadLink
-      document={<CVDocument data={data} labels={{ experience: t('experience'), education: t('education'), skills: t('skills') }} />}
-      fileName="cv.pdf"
-      className="px-4 py-2 bg-green-500 text-white rounded"
-    >
-      {({ loading }) => (loading ? t('generatingPdfButton') : t('exportPdf'))}
-    </PDFDownloadLink>
+    <>
+      <PDFDownloadLink
+        document={<CVDocument data={data} labels={{ experience: t('experience'), education: t('education'), skills: t('skills') }} />}
+        fileName="cv.pdf"
+        className="px-4 py-2 bg-green-500 text-white rounded"
+      >
+        {({ loading }) => {
+          if (loading !== loadingState) {
+            setLoadingState(loading);
+          }
+          return loading ? t('generatingPdfButton') : t('exportPdf');
+        }}
+      </PDFDownloadLink>
+      <Toast message="CV ready!" visible={showToast} onClose={() => setShowToast(false)} />
+    </>
   );
 }

--- a/frontend/src/components/ui/toast.js
+++ b/frontend/src/components/ui/toast.js
@@ -1,0 +1,18 @@
+import React, { useEffect } from 'react';
+
+export default function Toast({ message, visible, onClose }) {
+  useEffect(() => {
+    if (visible) {
+      const timer = setTimeout(onClose, 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [visible, onClose]);
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed bottom-4 right-4 bg-gray-800 text-white px-4 py-2 rounded shadow">
+      {message}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add toast component to display messages
- show "CV ready!" after PDF generation completes

## Testing
- `npm test -- --watchAll=false --passWithNoTests` (frontend)
- `npm test` (backend: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689649ce01f48327b564217e96e2e43b