### PR TITLE
Fix theme toggle and bump versions

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "CV Builder backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.3.20",
+  "version": "0.3.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.3.20",
+      "version": "0.3.21",
       "dependencies": {
         "@hookform/resolvers": "^3.3.4",
         "@radix-ui/react-dialog": "^1.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.3.20",
+  "version": "0.3.21",
   "private": true,
   "homepage": ".",
   "dependencies": {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,19 +1,13 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import ThemeSwitcher from './components/ThemeSwitcher';
 import LanguageSwitcher from './components/LanguageSwitcher';
 import CVBuilder from './components/CVBuilder';
 import ErrorBoundary from './components/ErrorBoundary';
 import ErrorScreen from './components/ErrorScreen';
+import { useTheme } from './hooks/useTheme';
 
 function App() {
-  const [theme, setTheme] = useState(() => localStorage.getItem('theme') || 'light');
-
-  useEffect(() => {
-    const root = document.documentElement;
-    root.classList.remove('light', 'dark');
-    root.classList.add(theme);
-    localStorage.setItem('theme', theme);
-  }, [theme]);
+  const [theme, setTheme] = useTheme();
 
   return (
     <ErrorBoundary fallback={<ErrorScreen />}>

--- a/frontend/src/hooks/useTheme.js
+++ b/frontend/src/hooks/useTheme.js
@@ -4,12 +4,14 @@ import { useState, useEffect } from 'react';
 export function useTheme() {
   const [theme, setTheme] = useState(() => {
     const savedTheme = localStorage.getItem('theme');
-    const userPrefersDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches;
-    return savedTheme || (userPrefersDark ? 'dark' : 'light');
+    const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches;
+    return savedTheme || (prefersDark ? 'dark' : 'light');
   });
 
   useEffect(() => {
-    document.body.className = theme;
+    const root = document.documentElement;
+    root.classList.remove('light', 'dark');
+    root.classList.add(theme);
     localStorage.setItem('theme', theme);
   }, [theme]);
 

--- a/package2.json
+++ b/package2.json
@@ -1,6 +1,6 @@
 {
   "name": "cvbuilder-monorepo",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": true,
   "workspaces": [
     "frontend",


### PR DESCRIPTION
## Summary
- fix theme toggler by managing root element classes for light/dark modes
- use dedicated theme hook in App
- bump frontend, backend, and monorepo versions

## Testing
- `CI=true npm test -- --passWithNoTests` (frontend)
- `npm test` (backend, fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68964d2eea0c832793588876225dc2d6